### PR TITLE
Upgrade oidc-starter to support new version of app

### DIFF
--- a/stable/dex-k8s-authenticator/Chart.yaml
+++ b/stable/dex-k8s-authenticator/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "1.1.0"
 description: Authenticator for using Dex with Kubernetes
 name: dex-k8s-authenticator
-version: 1.0.0
+version: 1.1.0
 home: https://github.com/mintel/dex-k8s-authenticator

--- a/stable/dex-k8s-authenticator/Chart.yaml
+++ b/stable/dex-k8s-authenticator/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.1.0"
+appVersion: "v1.4.0"
 description: Authenticator for using Dex with Kubernetes
 name: dex-k8s-authenticator
 version: 1.1.0

--- a/stable/dex-k8s-authenticator/templates/deployment.yaml
+++ b/stable/dex-k8s-authenticator/templates/deployment.yaml
@@ -35,10 +35,12 @@ spec:
             httpGet:
               path: {{ template "dex-k8s-authenticator.healthCheckPath" . }}
               port: http
+            initialDelaySeconds: 5
           readinessProbe:
             httpGet:
               path: {{ template "dex-k8s-authenticator.healthCheckPath" . }}
               port: http
+            initialDelaySeconds: 5
           volumeMounts:
           - name: config
             subPath: config.yaml

--- a/stable/dex-k8s-authenticator/templates/ingress.yaml
+++ b/stable/dex-k8s-authenticator/templates/ingress.yaml
@@ -37,4 +37,4 @@ spec:
               servicePort: http
           {{- end }}
     {{- end }}
-  {{- end }}
+{{- end }}

--- a/stable/dex-k8s-authenticator/templates/servicemonitor.yaml
+++ b/stable/dex-k8s-authenticator/templates/servicemonitor.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.servicemonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "dex-k8s-authenticator.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "dex-k8s-authenticator.name" . }}
+    helm.sh/chart: {{ include "dex-k8s-authenticator.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "dex-k8s-authenticator.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  endpoints:
+    - port: http
+{{- end }}

--- a/stable/dex-k8s-authenticator/values.yaml
+++ b/stable/dex-k8s-authenticator/values.yaml
@@ -104,6 +104,9 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+servicemonitor:
+  enabled: false
+
 resources:
   limits:
     cpu: 8m

--- a/stable/dex-k8s-authenticator/values.yaml
+++ b/stable/dex-k8s-authenticator/values.yaml
@@ -5,8 +5,8 @@
 replicaCount: 1
 
 image:
-  repository: mintel/dex-k8s-authenticator
-  tag: 1.1.0
+  repository: anchorfree/dex-k8s-authenticator
+  tag: v1.4.0
   pullPolicy: IfNotPresent
 
 nameOverride: ""

--- a/stable/oidc-starter/Chart.yaml
+++ b/stable/oidc-starter/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.0.0"
+appVersion: "v1.0.0"
 description: Authenticator for using Dex with Hashicorp Vault
 name: oidc-starter
 version: 2.0.0

--- a/stable/oidc-starter/Chart.yaml
+++ b/stable/oidc-starter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-appVersion: "0.0.2"
+appVersion: "1.0.0"
 description: Authenticator for using Dex with Hashicorp Vault
 name: oidc-starter
-version: 1.0.0
+version: 2.0.0
 home: https://github.com/AnchorFree/oidc-starter

--- a/stable/oidc-starter/templates/_helpers.tpl
+++ b/stable/oidc-starter/templates/_helpers.tpl
@@ -30,3 +30,18 @@ Create chart name and version as used by the chart label.
 {{- define "oidc-starter.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "-" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create healthcheck path dependent on web_path_prefix
+*/}}
+{{- define "oidc-starter.healthCheckPath" -}}
+{{- if .Values.healthCheckPath -}}
+  {{ .Values.healthCheckPath }}
+{{- else -}}
+  {{- if .Values.oidc_starter.webPathPrefix -}}
+    {{ .Values.oidc_starter.webPathPrefix | trimSuffix "/" }}/healthz
+  {{- else -}}
+    {{ "/healthz" }}
+  {{- end -}}
+{{- end -}}
+{{- end -}}

--- a/stable/oidc-starter/templates/deployment.yaml
+++ b/stable/oidc-starter/templates/deployment.yaml
@@ -23,8 +23,7 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command:
-          - /bin/oidc-starter
+          args:
           - --listen=http://0.0.0.0:80
           - --client-id=$(CLIENT_ID)
           - --client-secret=$(CLIENT_SECRET)
@@ -35,7 +34,7 @@ spec:
           - --redirect-uri={{ .Values.oidc_starter.redirectURI }}
           {{- end }}
           {{- if .Values.oidc_starter.webPathPrefix }}
-          - --base-redirect-uri={{ .Values.oidc_starter.webPathPrefix }}
+          - --web-path-prefix={{ .Values.oidc_starter.webPathPrefix }}
           {{- end }}
           {{- if .Values.oidc_starter.debug }}
           - --debug
@@ -59,10 +58,12 @@ spec:
             httpGet:
               path: {{ template "oidc-starter.healthCheckPath" . }}
               port: http
+            initialDelaySeconds: 5
           readinessProbe:
             httpGet:
               path: {{ template "oidc-starter.healthCheckPath" . }}
               port: http
+            initialDelaySeconds: 5
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/stable/oidc-starter/templates/deployment.yaml
+++ b/stable/oidc-starter/templates/deployment.yaml
@@ -34,8 +34,8 @@ spec:
           {{- if .Values.oidc_starter.redirectURI }}
           - --redirect-uri={{ .Values.oidc_starter.redirectURI }}
           {{- end }}
-          {{- if .Values.oidc_starter.baseRedirectURI }}
-          - --base-redirect-uri={{ .Values.oidc_starter.baseRedirectURI }}
+          {{- if .Values.oidc_starter.webPathPrefix }}
+          - --base-redirect-uri={{ .Values.oidc_starter.webPathPrefix }}
           {{- end }}
           {{- if .Values.oidc_starter.debug }}
           - --debug

--- a/stable/oidc-starter/templates/deployment.yaml
+++ b/stable/oidc-starter/templates/deployment.yaml
@@ -55,6 +55,14 @@ spec:
               secretKeyRef:
                 name: {{ include "oidc-starter.fullname" . }}
                 key: client-secret
+          livenessProbe:
+            httpGet:
+              path: {{ template "oidc-starter.healthCheckPath" . }}
+              port: http
+          readinessProbe:
+            httpGet:
+              path: {{ template "oidc-starter.healthCheckPath" . }}
+              port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/stable/oidc-starter/templates/ingress.yaml
+++ b/stable/oidc-starter/templates/ingress.yaml
@@ -37,4 +37,4 @@ spec:
               servicePort: http
   {{- end }}
   {{- end }}
-  {{- end }}
+{{- end }}

--- a/stable/oidc-starter/templates/servicemonitor.yaml
+++ b/stable/oidc-starter/templates/servicemonitor.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.servicemonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "oidc-starter.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "oidc-starter.name" . }}
+    helm.sh/chart: {{ include "oidc-starter.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "oidc-starter.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  endpoints:
+  - port: http
+{{- end }}

--- a/stable/oidc-starter/values.yaml
+++ b/stable/oidc-starter/values.yaml
@@ -38,6 +38,9 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+servicemonitor:
+  enabled: false
+
 resources:
   limits:
     cpu: 16m

--- a/stable/oidc-starter/values.yaml
+++ b/stable/oidc-starter/values.yaml
@@ -6,11 +6,12 @@ replicaCount: 1
 
 image:
   repository: anchorfree/oidc-starter
-  tag: 0.0.2
+  tag: v1.0.0
   pullPolicy: IfNotPresent
 
 nameOverride: ""
 fullnameOverride: ""
+healthCheckPath: ""
 
 oidc_starter:
   debug: true
@@ -18,7 +19,7 @@ oidc_starter:
   clientId: example-client-id
   clientSecret: ZXhhbXBsZS1hcHAtc2VjcmV0
   redirectURI: http://127.0.0.1:5555/callback
-  baseRedirectURI: /callback
+  webPathPrefix: /
 
 service:
   type: ClusterIP


### PR DESCRIPTION
#### What this PR does / why we need it:
* Upgrade oidc-starter helm chart to support new version of app
* Add prometeus-operator servicemonitor crd to monitor oidc-starter service
* Upgrade dex-k8s-authenticator helm chart to support new version of app
* Add prometeus-operator servicemonitor crd to monitor dex-k8s-authenticator service