### PR TITLE
INFRA-7832 Use secret instead of plain env vars

### DIFF
--- a/stable/legacy-cert-manager/Chart.yaml
+++ b/stable/legacy-cert-manager/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "1.0"
 description: Chart to create a deployment of legacy cert-manager for non k8s-projects
 name: legacy-cert-manager
-version: 1.0.1
+version: 1.0.2
 home: https://github.com/AnchorFree/docker-cert-manager/

--- a/stable/legacy-cert-manager/templates/deployment.yaml
+++ b/stable/legacy-cert-manager/templates/deployment.yaml
@@ -30,6 +30,9 @@ spec:
         image: {{ if eq .Values.acme "v2" }}{{ .Values.image_v2 }}{{ else }}{{ .Values.image }}{{ end }}
         ports:
         - containerPort: 9375
+        envFrom:
+          secretRef:
+            name: {{ .Release.Name }}-aws-secret
         env:
 {{ toYaml .Values.env | indent 10 }}
 {{ if eq .Values.acme "v2" }}

--- a/stable/legacy-cert-manager/templates/secret.yaml
+++ b/stable/legacy-cert-manager/templates/secret.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: {{ .Chart.Name }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    release: {{ .Relese.Name }}
+    release: {{ .Release.Name }}
 data:
   AWS_ACCESS_KEY_ID: |-
     {{ .Values.aws_key | b64enc }}

--- a/stable/legacy-cert-manager/templates/secret.yaml
+++ b/stable/legacy-cert-manager/templates/secret.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-aws-secret
+  labels:
+    app: {{ .Chart.Name }}
+    chart: {{ .Chart.Name }}-{{ .Chart.version }}
+    release: {{ .Relese.Name }}
+data:
+  AWS_ACCESS_KEY_ID: |-
+    {{ .Values.aws_key | b64enc }}
+  AWS_SECRET_ACCESS_KEY: |-
+    {{ .Values.aws_secret | b64enc }}

--- a/stable/legacy-cert-manager/templates/secret.yaml
+++ b/stable/legacy-cert-manager/templates/secret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ .Release.Name }}-aws-secret
   labels:
     app: {{ .Chart.Name }}
-    chart: {{ .Chart.Name }}-{{ .Chart.version }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     release: {{ .Relese.Name }}
 data:
   AWS_ACCESS_KEY_ID: |-

--- a/stable/legacy-cert-manager/templates/service.yaml
+++ b/stable/legacy-cert-manager/templates/service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: legacy-cert-manager
+  name: {{ .Release.Name }}
   labels:
     app: {{ .Chart.Name }}
     release: {{ .Release.Name }}

--- a/stable/legacy-cert-manager/values.yaml
+++ b/stable/legacy-cert-manager/values.yaml
@@ -4,6 +4,8 @@ acme_url: "https://acme-v02.api.letsencrypt.org/directory"
 port: "9375"
 image: "anchorfree/cert-manager:v0.0.3"
 image_v2: "anchorfree/cert-manager:v0.0.4"
+aws_key: "xxx"
+aws_secret: "xxx"
 env:
 - name: LEGO_PATH
   value: "/usr/local/bin/lego"
@@ -11,10 +13,6 @@ env:
   value: "uniq-email@per.account"
 - name: AWS_REGION
   value: "us-east-1"
-- name: AWS_ACCESS_KEY_ID
-  value: "xxx"
-- name: AWS_SECRET_ACCESS_KEY
-  value: "xxx"
 - name: S3_BUCKET
   value: "s3://some-bucket"
 - name: DOMAINS_FILE


### PR DESCRIPTION
#### What this PR does / why we need it:
Use secret in legacy-cert-manager chart instead of plain env vars.

#### Which issue this PR fixes if any
If we use plain env vars, AWS creds are shown in plain text during CI stage.

