### PR TITLE
add prometheus-cloudwatch-exporter

### DIFF
--- a/stable/prometheus-cloudwatch-exporter/.helmignore
+++ b/stable/prometheus-cloudwatch-exporter/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/stable/prometheus-cloudwatch-exporter/Chart.yaml
+++ b/stable/prometheus-cloudwatch-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.5.0"
 description: A Helm chart for prometheus cloudwatch-exporter
 name: prometheus-cloudwatch-exporter
-version: 0.4.1
+version: 0.4.2
 home: https://github.com/prometheus/cloudwatch_exporter
 sources:
 - https://github.com/prometheus/cloudwatch_exporter

--- a/stable/prometheus-cloudwatch-exporter/Chart.yaml
+++ b/stable/prometheus-cloudwatch-exporter/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+appVersion: "0.5.0"
+description: A Helm chart for prometheus cloudwatch-exporter
+name: prometheus-cloudwatch-exporter
+version: 0.4.1
+home: https://github.com/prometheus/cloudwatch_exporter
+sources:
+- https://github.com/prometheus/cloudwatch_exporter
+keywords:
+- aws
+- cloudwatch
+- prometheus
+- exporter
+maintainers:
+- email: gianrubio@gmail.com
+  name: gianrubio

--- a/stable/prometheus-cloudwatch-exporter/Chart.yaml
+++ b/stable/prometheus-cloudwatch-exporter/Chart.yaml
@@ -12,5 +12,5 @@ keywords:
 - prometheus
 - exporter
 maintainers:
-- email: gianrubio@gmail.com
-  name: gianrubio
+- email: devops@anchorfree.com
+  name: anchorfree

--- a/stable/prometheus-cloudwatch-exporter/OWNERS
+++ b/stable/prometheus-cloudwatch-exporter/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- gianrubio
+reviewers:
+- gianrubio

--- a/stable/prometheus-cloudwatch-exporter/README.md
+++ b/stable/prometheus-cloudwatch-exporter/README.md
@@ -67,8 +67,8 @@ The following table lists the configurable parameters of the Cloudwatch Exporter
 | `aws.aws_secret_access_key` | AWS secret access key                                  |                            |
 | `aws.secret.name` | The name of a pre-created secret in which AWS credentials are stored                                 |                            |
 | `aws.secret.includesSessionToken` |  Whether or not the pre-created secret contains an AWS STS session token                                  |                            |
-| `config`                    | Map with Cloudwatch exporter configuration, see values for example             | `example configuration`    |
-| `predefinedMetrics`         | Predefined metrics types that can be used in config section described above | `` |
+| `config`                    | Map with Cloudwatch exporter configuration, see values for example             | `see default values.yaml`    |
+| `predefinedMetrics`         | Predefined metrics types that can be used in config section described above | `see default values.yaml` |
 | `rbac.create`               | If true, create & use RBAC resources                   | `false`                    |
 | `serviceAccount.create`     | Specifies whether a service account should be created. | `true`                     |
 | `serviceAccount.name`       | Name of the service account.                           |                            |
@@ -78,8 +78,8 @@ The following table lists the configurable parameters of the Cloudwatch Exporter
 | `livenessProbe`             | Liveness probe settings                                |                            |
 | `readinessProbe`            | Readiness probe settings                               |                            |
 | `serviceMonitor.enable`     | If enabled chart will create servicemonitor resource   | `false`                    |
-| `serviceMonitor.scrapeInterval` | Period of scraping metrics from cloudwatch exporter| `60s`                      |
-| `serviceMonitor.scrapeTimeout` | Timeout for scraping metrics from cloudwatch exporter| `59s`                      |
+| `serviceMonitor.scrapeInterval` | Period of scraping metrics from cloudwatch exporter| `inherit from prometheus`                      |
+| `serviceMonitor.scrapeTimeout` | Timeout for scraping metrics from cloudwatch exporter| `inherit from prometheus`                      |
 | `serviceMonitor.namespace` | Namespace in which serviceonitor resource will be created | `monitoring`             |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/stable/prometheus-cloudwatch-exporter/README.md
+++ b/stable/prometheus-cloudwatch-exporter/README.md
@@ -1,0 +1,97 @@
+# Cloudwatch exporter
+
+this is a modified fork of https://github.com/helm/charts/tree/master/stable/prometheus-cloudwatch-exporter
+
+* Installs [cloudwatch exporter](http://github.com/prometheus/cloudwatch_exporter)
+
+## TL;DR;
+
+```console
+$ helm install stable/prometheus-cloudwatch-exporter
+```
+
+## Introduction
+
+This chart bootstraps a [cloudwatch exporter](http://github.com/prometheus/cloudwatch_exporter) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+
+- [kube2iam](../../stable/kube2iam) installed to used the **aws.role** config option otherwise configure **aws.aws_access_key_id** and **aws.aws_secret_access_key** or **aws.secret.name**
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+$ # pass AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY as values
+$ helm install --name my-release stable/prometheus-cloudwatch-exporter --set aws.aws_access_key_id=$AWS_ACCESS_KEY_ID,aws.aws_secret_access_key=$AWS_SECRET_ACCESS_KEY
+
+$ # or store them in a secret and pass its name as a value
+$ kubectl create secret generic <SECRET_NAME> --from-literal=access_key=$AWS_ACCESS_KEY_ID --from-literal=secret_key=$AWS_SECRET_ACCESS_KEY
+$ helm install --name my-release stable/prometheus-cloudwatch-exporter --set aws.secret.name=<SECRET_NAME>
+
+$ # or add a role to aws with the [correct policy](https://github.com/prometheus/cloudwatch_exporter#credentials-and-permissions) to add to cloud watch and pass its name as a value
+$ helm install --name my-release stable/prometheus-cloudwatch-exporter --set awsRole=<ROLL_NAME>
+```
+
+The command deploys Cloudwatch exporter on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following table lists the configurable parameters of the Cloudwatch Exporter chart and their default values.
+
+|          Parameter          |                      Description                       |          Default           |
+| --------------------------- | ------------------------------------------------------ | -------------------------- |
+| `image.repository`          | Image                                                  | `prom/cloudwatch-exporter` |
+| `image.tag`                 | Image tag                                              | `cloudwatch_exporter-0.5.0`                   |
+| `image.pullPolicy`          | Image pull policy                                      | `IfNotPresent`             |
+| `service.type`              | Service type                                           | `ClusterIP`                |
+| `service.port`              | The service port                                       | `9106`                     |
+| `service.targetPort`        | The service target port                                | `9106`                     |
+| `service.portName`          | The name of the service port                           | `http`                     |
+| `service.annotations`       | Custom annotations for service                         | `{}`                       |
+| `service.labels`            | Additional custom labels for the service               | `{}`                       |
+| `resources`                 |                                                        | `{}`                       |
+| `aws.role`                  | AWS IAM Role To Use                                    |                            |
+| `aws.aws_access_key_id`     | AWS access key id                                      |                            |
+| `aws.aws_secret_access_key` | AWS secret access key                                  |                            |
+| `aws.secret.name` | The name of a pre-created secret in which AWS credentials are stored                                 |                            |
+| `aws.secret.includesSessionToken` |  Whether or not the pre-created secret contains an AWS STS session token                                  |                            |
+| `config`                    | Map with Cloudwatch exporter configuration, see values for example             | `example configuration`    |
+| `predefinedMetrics`         | Predefined metrics types that can be used in config section described above | `` |
+| `rbac.create`               | If true, create & use RBAC resources                   | `false`                    |
+| `serviceAccount.create`     | Specifies whether a service account should be created. | `true`                     |
+| `serviceAccount.name`       | Name of the service account.                           |                            |
+| `tolerations`               | Add tolerations                                        | `[]`                       |
+| `nodeSelector`              | node labels for pod assignment                         | `{}`                       |
+| `affinity`                  | node/pod affinities                                    | `{}`                       |
+| `livenessProbe`             | Liveness probe settings                                |                            |
+| `readinessProbe`            | Readiness probe settings                               |                            |
+| `serviceMonitor.enable`     | If enabled chart will create servicemonitor resource   | `false`                    |
+| `serviceMonitor.scrapeInterval` | Period of scraping metrics from cloudwatch exporter| `60s`                      |
+| `serviceMonitor.scrapeTimeout` | Timeout for scraping metrics from cloudwatch exporter| `59s`                      |
+| `serviceMonitor.namespace` | Namespace in which serviceonitor resource will be created | `monitoring`             |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```console
+$ helm install --name my-release \
+    --set aws.role=my-aws-role \
+    stable/prometheus-cloudwatch-exporter
+```
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```console
+$ helm install --name my-release -f values.yaml stable/prometheus-cloudwatch-exporter
+```

--- a/stable/prometheus-cloudwatch-exporter/templates/NOTES.txt
+++ b/stable/prometheus-cloudwatch-exporter/templates/NOTES.txt
@@ -1,0 +1,15 @@
+1. Get the application URL by running these commands:
+{{- if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "prometheus-cloudwatch-exporter.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "prometheus-cloudwatch-exporter.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "prometheus-cloudwatch-exporter.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "prometheus-cloudwatch-exporter.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:80
+{{- end }}

--- a/stable/prometheus-cloudwatch-exporter/templates/_helpers.tpl
+++ b/stable/prometheus-cloudwatch-exporter/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "prometheus-cloudwatch-exporter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "prometheus-cloudwatch-exporter.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "prometheus-cloudwatch-exporter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/stable/prometheus-cloudwatch-exporter/templates/_helpers.tpl
+++ b/stable/prometheus-cloudwatch-exporter/templates/_helpers.tpl
@@ -13,13 +13,13 @@ If release name contains chart name it will be used as a full name.
 */}}
 {{- define "prometheus-cloudwatch-exporter.fullname" -}}
 {{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- .Values.fullnameOverride | trunc 53 | trimSuffix "-" -}}
 {{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- .Release.Name | trunc 53 | trimSuffix "-" -}}
 {{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 53 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/stable/prometheus-cloudwatch-exporter/templates/clusterrole.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/clusterrole.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: {{ template "prometheus-cloudwatch-exporter.name" . }}
+    chart: {{ template "prometheus-cloudwatch-exporter.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets","configmap"]
+    resourceNames:
+{{- $root := . -}}
+{{- range $region, $options := .Values.config }}
+      - {{ $root.Release.Name }}-{{ $region }}
+{{- end }}
+    verbs: ["get"]
+{{- end }}

--- a/stable/prometheus-cloudwatch-exporter/templates/clusterrole.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/clusterrole.yaml
@@ -1,8 +1,8 @@
 {{- if .Values.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ template "prometheus-cloudwatch-exporter.fullname" . }}
   labels:
     app: {{ template "prometheus-cloudwatch-exporter.name" . }}
     chart: {{ template "prometheus-cloudwatch-exporter.chart" . }}
@@ -14,7 +14,7 @@ rules:
     resourceNames:
 {{- $root := . -}}
 {{- range $region, $options := .Values.config }}
-      - {{ $root.Release.Name }}-{{ $region }}
+      - {{ template "prometheus-cloudwatch-exporter.fullname" $root }}-{{ $region }}
 {{- end }}
     verbs: ["get"]
 {{- end }}

--- a/stable/prometheus-cloudwatch-exporter/templates/clusterrolebinding.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/clusterrolebinding.yaml
@@ -1,8 +1,8 @@
 {{ if .Values.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ template "prometheus-cloudwatch-exporter.fullname" . }}
   labels:
     app: {{ template "prometheus-cloudwatch-exporter.name" . }}
     chart: {{ template "prometheus-cloudwatch-exporter.chart" . }}

--- a/stable/prometheus-cloudwatch-exporter/templates/clusterrolebinding.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+{{ if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: {{ template "prometheus-cloudwatch-exporter.name" . }}
+    chart: {{ template "prometheus-cloudwatch-exporter.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Release.Name }}
+  apiGroup: rbac.authorization.k8s.io
+{{ end }}

--- a/stable/prometheus-cloudwatch-exporter/templates/configmap.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/configmap.yaml
@@ -1,0 +1,31 @@
+{{- $root := . -}}
+{{- range $region, $options := .Values.config }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $root.Release.Name }}-{{ $region }}
+  labels:
+    app: {{ template "prometheus-cloudwatch-exporter.name" $root }}
+    chart: {{ template "prometheus-cloudwatch-exporter.chart" $root }}
+    release: {{ $root.Release.Name }}
+    heritage: {{ $root.Release.Service }}
+    region: {{ $region }}
+data:
+  config.yml: |-
+    region: {{ $region }}
+{{- range $key, $value := $options.globalOptions }}
+    {{ $key }}: {{ $value }}
+{{- end }}
+    metrics:
+{{- if $options.customMetrics }}
+{{ printf $options.customMetrics | indent 6 }}
+{{- end }}
+{{- range $metricsTypeName := $options.metricTypes }}
+{{- range $predefinedMetricName, $predefinedMetrics:= $root.Values.predefinedMetrics }}
+{{- if eq (print $metricsTypeName) (print $predefinedMetricName) }}
+{{ printf $predefinedMetrics | indent 6 }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/stable/prometheus-cloudwatch-exporter/templates/configmap.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/configmap.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ $root.Release.Name }}-{{ $region }}
+  name: {{ template "prometheus-cloudwatch-exporter.fullname" $root }}-{{ $region }}
   labels:
     app: {{ template "prometheus-cloudwatch-exporter.name" $root }}
     chart: {{ template "prometheus-cloudwatch-exporter.chart" $root }}

--- a/stable/prometheus-cloudwatch-exporter/templates/deployment.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/deployment.yaml
@@ -4,7 +4,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ $root.Release.Name }}-{{ $region }}
+  name: {{ template "prometheus-cloudwatch-exporter.fullname" $root }}-{{ $region }}
   labels:
     app: {{ template "prometheus-cloudwatch-exporter.name" $root }}
     chart: {{ template "prometheus-cloudwatch-exporter.chart" $root }}
@@ -56,24 +56,24 @@ spec:
               valueFrom:
                 secretKeyRef:
                   key: aws_access_key_id
-                  name: {{ $root.Release.Name }}
+                  name: {{ template "prometheus-cloudwatch-exporter.fullname" $root }}
             - name: AWS_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
                   key: aws_secret_access_key
-                  name: {{ $root.Release.Name }}
+                  name: {{ template "prometheus-cloudwatch-exporter.fullname" $root }}
           {{- end }}
           {{- end }}
           image: "{{ $root.Values.image.repository }}:{{ $root.Values.image.tag }}"
           imagePullPolicy: {{ $root.Values.image.pullPolicy }}
           ports:
-            - name: {{ $root.Values.service.portName }}
+            - name: container-port
               containerPort: 9106
               protocol: TCP
           livenessProbe:
             httpGet:
               path: /-/healthy
-              port: {{ $root.Values.service.portName }}
+              port: container-port
             initialDelaySeconds: {{ $root.Values.livenessProbe.initialDelaySeconds}}
             periodSeconds: {{ $root.Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ $root.Values.livenessProbe.timeoutSeconds }}
@@ -82,7 +82,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /-/ready
-              port: {{ $root.Values.service.portName }}
+              port: container-port
             initialDelaySeconds: {{ $root.Values.readinessProbe.initialDelaySeconds}}
             periodSeconds: {{ $root.Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ $root.Values.readinessProbe.timeoutSeconds }}
@@ -108,7 +108,7 @@ spec:
       volumes:
       - configMap:
           defaultMode: 420
-          name: {{ $root.Release.Name }}-{{ $region }}
+          name: {{ template "prometheus-cloudwatch-exporter.fullname" $root }}-{{ $region }}
         name: vol-prometheus-cloudwatch-exporter
 
 {{- end }}

--- a/stable/prometheus-cloudwatch-exporter/templates/deployment.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/deployment.yaml
@@ -1,0 +1,114 @@
+{{- $root := . -}}
+{{- range $region, $options := .Values.config }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $root.Release.Name }}-{{ $region }}
+  labels:
+    app: {{ template "prometheus-cloudwatch-exporter.name" $root }}
+    chart: {{ template "prometheus-cloudwatch-exporter.chart" $root }}
+    release: {{ $root.Release.Name }}
+    heritage: {{ $root.Release.Service }}
+    region: {{ $region }}
+spec:
+  replicas: {{ $root.Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "prometheus-cloudwatch-exporter.name" $root }}
+      release: {{ $root.Release.Name }}
+      region: {{ $region }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "prometheus-cloudwatch-exporter.name" $root }}
+        release: {{ $root.Release.Name }}
+        region: {{ $region }}
+      annotations:
+        {{ if $root.Values.aws.role}}iam.amazonaws.com/role: {{ $root.Values.aws.role }}{{ end }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") $root | sha256sum }}
+    spec:
+      containers:
+        - name: {{ $root.Chart.Name }}
+        {{- if not $root.Values.aws.role }}
+        {{- if $root.Values.aws.secret.name }}
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  key: access_key
+                  name: {{ $root.Values.aws.secret.name }}
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: secret_key
+                  name: {{ $root.Values.aws.secret.name }}
+          {{- if $root.Values.aws.secret.includesSessionToken }}
+            - name: AWS_SESSION_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  key: security_token
+                  name: {{ $root.Values.aws.secret.name }}
+          {{- end }}
+        {{- else if and $root.Values.aws.aws_secret_access_key $root.Values.aws.aws_access_key_id }}
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  key: aws_access_key_id
+                  name: {{ $root.Release.Name }}
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: aws_secret_access_key
+                  name: {{ $root.Release.Name }}
+          {{- end }}
+          {{- end }}
+          image: "{{ $root.Values.image.repository }}:{{ $root.Values.image.tag }}"
+          imagePullPolicy: {{ $root.Values.image.pullPolicy }}
+          ports:
+            - name: {{ $root.Values.service.portName }}
+              containerPort: 9106
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /-/healthy
+              port: {{ $root.Values.service.portName }}
+            initialDelaySeconds: {{ $root.Values.livenessProbe.initialDelaySeconds}}
+            periodSeconds: {{ $root.Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ $root.Values.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ $root.Values.livenessProbe.successThreshold }}
+            failureThreshold: {{ $root.Values.livenessProbe.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: {{ $root.Values.service.portName }}
+            initialDelaySeconds: {{ $root.Values.readinessProbe.initialDelaySeconds}}
+            periodSeconds: {{ $root.Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ $root.Values.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ $root.Values.readinessProbe.successThreshold }}
+            failureThreshold: {{ $root.Values.readinessProbe.failureThreshold }}
+          resources:
+{{ toYaml $root.Values.resources | indent 12 }}
+          volumeMounts:
+            - name: vol-prometheus-cloudwatch-exporter
+              mountPath: /config
+     {{- with $root.Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with $root.Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with $root.Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: {{ $root.Release.Name }}-{{ $region }}
+        name: vol-prometheus-cloudwatch-exporter
+
+{{- end }}

--- a/stable/prometheus-cloudwatch-exporter/templates/secrets.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/secrets.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ template "prometheus-cloudwatch-exporter.fullname" . }}
   labels:
     app: {{ template "prometheus-cloudwatch-exporter.name" . }}
     chart: {{ template "prometheus-cloudwatch-exporter.chart" . }}

--- a/stable/prometheus-cloudwatch-exporter/templates/secrets.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/secrets.yaml
@@ -1,0 +1,19 @@
+{{- if and (not .Values.aws.role) (not .Values.aws.secret.name) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: {{ template "prometheus-cloudwatch-exporter.name" . }}
+    chart: {{ template "prometheus-cloudwatch-exporter.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+type: Opaque
+data:
+  {{ if .Values.aws.aws_access_key_id }}
+  aws_access_key_id: {{ .Values.aws.aws_access_key_id | b64enc | quote }}
+  {{ end }}
+  {{ if .Values.aws.aws_secret_access_key }}
+  aws_secret_access_key: {{ .Values.aws.aws_secret_access_key | b64enc | quote }}
+  {{ end }}
+{{- end }}

--- a/stable/prometheus-cloudwatch-exporter/templates/service.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/service.yaml
@@ -1,0 +1,31 @@
+{{- $root := . -}}
+{{- range $region, $options := .Values.config }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $root.Release.Name }}-{{ $region }}
+  annotations:
+{{ toYaml $root.Values.service.annotations | indent 4 }}
+  labels:
+    app: {{ template "prometheus-cloudwatch-exporter.name" $root }}
+    chart: {{ template "prometheus-cloudwatch-exporter.chart" $root }}
+    release: {{ $root.Release.Name }}
+    heritage: {{ $root.Release.Service }}
+    region: {{ $region }}
+{{- if $root.Values.service.labels }}
+{{ toYaml $root.Values.service.labels | indent 4 }}
+{{- end }}
+spec:
+  type: {{ $root.Values.service.type }}
+  ports:
+    - port: {{ $root.Values.service.port }}
+      targetPort: {{ $root.Values.service.targetPort }}
+      protocol: TCP
+      name: {{ $root.Values.service.portName }}
+  selector:
+    app: {{ template "prometheus-cloudwatch-exporter.name" $root }}
+    release: {{ $root.Release.Name }}
+    region: {{ $region }}
+
+{{- end }}

--- a/stable/prometheus-cloudwatch-exporter/templates/service.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/service.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ $root.Release.Name }}-{{ $region }}
+  name: {{ template "prometheus-cloudwatch-exporter.fullname" $root }}-{{ $region }}
   annotations:
 {{ toYaml $root.Values.service.annotations | indent 4 }}
   labels:
@@ -20,7 +20,7 @@ spec:
   type: {{ $root.Values.service.type }}
   ports:
     - port: {{ $root.Values.service.port }}
-      targetPort: {{ $root.Values.service.targetPort }}
+      targetPort: container-port
       protocol: TCP
       name: {{ $root.Values.service.portName }}
   selector:

--- a/stable/prometheus-cloudwatch-exporter/templates/serviceaccount.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: {{ template "prometheus-cloudwatch-exporter.name" . }}
+    chart: {{ template "prometheus-cloudwatch-exporter.chart" . }}    
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+{{- end }}

--- a/stable/prometheus-cloudwatch-exporter/templates/serviceaccount.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ template "prometheus-cloudwatch-exporter.fullname" . }}
   labels:
     app: {{ template "prometheus-cloudwatch-exporter.name" . }}
     chart: {{ template "prometheus-cloudwatch-exporter.chart" . }}    

--- a/stable/prometheus-cloudwatch-exporter/templates/servicemonitor.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/servicemonitor.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.serviceMonitor.enable }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "prometheus-cloudwatch-exporter.fullname" . }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+  labels:
+    app: {{ template "prometheus-cloudwatch-exporter.name" . }}
+    chart: {{ template "prometheus-cloudwatch-exporter.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    k8s-app: {{ template "prometheus-cloudwatch-exporter.name" . }}
+spec:
+  jobLabel: name
+  endpoints:
+  - port: {{ .Values.service.portName }}
+    interval: {{ .Values.serviceMonitor.scrapeInterval }}
+    scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+  selector:
+    matchLabels:
+      release: {{ .Release.Name }}
+      app: {{ template "prometheus-cloudwatch-exporter.name" . }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  targetLabels:
+    - region
+{{- end }}

--- a/stable/prometheus-cloudwatch-exporter/templates/servicemonitor.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/servicemonitor.yaml
@@ -15,8 +15,12 @@ spec:
   jobLabel: name
   endpoints:
   - port: {{ .Values.service.portName }}
+{{- if .Values.serviceMonitor.scrapeInterval }}
     interval: {{ .Values.serviceMonitor.scrapeInterval }}
+{{- end }}
+{{- if .Values.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+{{- end }}
   selector:
     matchLabels:
       release: {{ .Release.Name }}

--- a/stable/prometheus-cloudwatch-exporter/values.yaml
+++ b/stable/prometheus-cloudwatch-exporter/values.yaml
@@ -1,0 +1,456 @@
+# Default values for prometheus-cloudwatch-exporter.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: prom/cloudwatch-exporter
+  tag: cloudwatch_exporter-0.5.0
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 9106
+  targetPort: 9106
+  portName: http
+  annotations: {}
+  labels: {}
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #    memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+aws:
+  role:
+
+  # The name of a pre-created secret in which AWS credentials are stored. When
+  # set, aws_access_key_id is assumed to be in a field called access_key,
+  # aws_secret_access_key is assumed to be in a field called secret_key, and the
+  # session token, if it exists, is assumed to be in a field called
+  # security_token
+  secret:
+    name:
+    includesSessionToken: false
+
+  # Note: Do not specify the aws_access_key_id and aws_secret_access_key if you specified role or secret.name before
+  aws_access_key_id:
+  aws_secret_access_key:
+
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# Configurable health checks against the /healthy and /ready endpoints
+livenessProbe:
+  initialDelaySeconds: 30
+  periodSeconds: 5
+  timeoutSeconds: 5
+  successThreshold: 1
+  failureThreshold: 3
+
+readinessProbe:
+  initialDelaySeconds: 30
+  periodSeconds: 5
+  timeoutSeconds: 5
+  successThreshold: 1
+  failureThreshold: 3
+
+serviceMonitor:
+  enable: false
+  scrapeInterval: 60s
+  scrapeTimeout: 59s
+  namespace: monitoring
+
+config: {}
+#  us-west-2:
+#    customMetrics: |-
+#      - aws_namespace: AWS/S3
+#        aws_metric_name: BucketSizeBytes
+#        aws_dimensions: [BucketName, StorageType]
+#        aws_statistics: [Average]
+#        range_seconds: 172800
+#        period_seconds: 86400
+#        set_timestamp: false
+#
+#    globalOptions:
+#      period_seconds: 300
+#    metricTypes:
+#    - s3
+#  us-west-1:
+#    globalOptions:
+#      period_seconds: 60
+#    metricTypes:
+#    - s3
+
+predefinedMetrics:
+  s3: |-
+    # s3
+    - aws_namespace: AWS/S3
+      aws_metric_name: BucketSizeBytes
+      aws_dimensions: [BucketName, StorageType]
+      aws_statistics: [Average]
+      range_seconds: 172800
+      period_seconds: 86400
+      set_timestamp: false
+
+    - aws_namespace: AWS/S3
+      aws_metric_name: NumberOfObjects
+      aws_dimensions: [BucketName, StorageType]
+      aws_statistics: [Average]
+      range_seconds: 172800
+      period_seconds: 86400
+      set_timestamp: false
+
+      # s3 paid metrics
+    - aws_namespace: AWS/S3
+      aws_metric_name: AllRequests
+      aws_dimensions: [BucketName, StorageType]
+      aws_statistics: [Average]
+      set_timestamp: false
+
+    - aws_namespace: AWS/S3
+      aws_metric_name: GetRequests
+      aws_dimensions: [BucketName, StorageType]
+      aws_statistics: [Sum]
+      set_timestamp: false
+
+    - aws_namespace: AWS/S3
+      aws_metric_name: PutRequests
+      aws_dimensions: [BucketName, StorageType]
+      aws_statistics: [Sum]
+      set_timestamp: false
+
+    - aws_namespace: AWS/S3
+      aws_metric_name: DeleteRequests
+      aws_dimensions: [BucketName, StorageType]
+      aws_statistics: [Sum]
+      set_timestamp: false
+
+    - aws_namespace: AWS/S3
+      aws_metric_name: HeadRequests
+      aws_dimensions: [BucketName, StorageType]
+      aws_statistics: [Sum]
+      set_timestamp: false
+
+    - aws_namespace: AWS/S3
+      aws_metric_name: PostRequests
+      aws_dimensions: [BucketName, StorageType]
+      aws_statistics: [Sum]
+      set_timestamp: false
+
+    - aws_namespace: AWS/S3
+      aws_metric_name: SelectRequests
+      aws_dimensions: [BucketName, StorageType]
+      aws_statistics: [Sum]
+      set_timestamp: false
+
+    - aws_namespace: AWS/S3
+      aws_metric_name: SelectScannedBytes
+      aws_dimensions: [BucketName, StorageType]
+      aws_statistics: [Average]
+      set_timestamp: false
+
+    - aws_namespace: AWS/S3
+      aws_metric_name: SelectReturnedBytes
+      aws_dimensions: [BucketName, StorageType]
+      aws_statistics: [Average]
+      set_timestamp: false
+
+    - aws_namespace: AWS/S3
+      aws_metric_name: ListRequests
+      aws_dimensions: [BucketName, StorageType]
+      aws_statistics: [Sum]
+      set_timestamp: false
+
+    - aws_namespace: AWS/S3
+      aws_metric_name: BytesDownloaded
+      aws_dimensions: [BucketName, StorageType]
+      aws_statistics: [Average]
+      set_timestamp: false
+
+    - aws_namespace: AWS/S3
+      aws_metric_name: BytesUploaded
+      aws_dimensions: [BucketName, StorageType]
+      aws_statistics: [Average]
+      set_timestamp: false
+
+    - aws_namespace: AWS/S3
+      aws_metric_name: 4xxErrors
+      aws_dimensions: [BucketName, StorageType]
+      aws_statistics: [Average]
+      set_timestamp: false
+
+    - aws_namespace: AWS/S3
+      aws_metric_name: 5xxErrors
+      aws_dimensions: [BucketName, StorageType]
+      aws_statistics: [Average]
+      set_timestamp: false
+
+    - aws_namespace: AWS/S3
+      aws_metric_name: FirstByteLatency
+      aws_dimensions: [BucketName, StorageType]
+      aws_statistics: [Average]
+      set_timestamp: false
+
+    - aws_namespace: AWS/S3
+      aws_metric_name: TotalRequestLatency
+      aws_dimensions: [BucketName, StorageType]
+      aws_statistics: [Average]
+      set_timestamp: false
+
+  emr: |-
+    # EMR
+    - aws_namespace: AWS/ElasticMapReduce
+      aws_metric_name: IsIdle
+      aws_dimensions: [JobFlowId]
+      aws_statistics: [Average]
+      set_timestamp: false
+
+    - aws_namespace: AWS/ElasticMapReduce
+      aws_metric_name: ContainerAllocated
+      aws_dimensions: [JobFlowId]
+      aws_statistics: [Average]
+      set_timestamp: false
+
+    - aws_namespace: AWS/ElasticMapReduce
+      aws_metric_name: ContainerReserved
+      aws_dimensions: [JobFlowId]
+      aws_statistics: [Average]
+      set_timestamp: false
+
+    - aws_namespace: AWS/ElasticMapReduce
+      aws_metric_name: ContainerPending
+      aws_dimensions: [JobFlowId]
+      aws_statistics: [Average]
+      set_timestamp: false
+
+    - aws_namespace: AWS/ElasticMapReduce
+      aws_metric_name: AppsCompleted
+      aws_dimensions: [JobFlowId]
+      aws_statistics: [Average]
+      set_timestamp: false
+
+    - aws_namespace: AWS/ElasticMapReduce
+      aws_metric_name: AppsFailed
+      aws_dimensions: [JobFlowId]
+      aws_statistics: [Average]
+      set_timestamp: false
+
+    - aws_namespace: AWS/ElasticMapReduce
+      aws_metric_name: AppsKilled
+      aws_dimensions: [JobFlowId]
+      aws_statistics: [Average]
+      set_timestamp: false
+
+    - aws_namespace: AWS/ElasticMapReduce
+      aws_metric_name: AppsPending
+      aws_dimensions: [JobFlowId]
+      aws_statistics: [Average]
+      set_timestamp: false
+
+    - aws_namespace: AWS/ElasticMapReduce
+      aws_metric_name: AppsRunning
+      aws_dimensions: [JobFlowId]
+      aws_statistics: [Average]
+
+    - aws_namespace: AWS/ElasticMapReduce
+      aws_metric_name: AppsSubmitted
+      aws_dimensions: [JobFlowId]
+      aws_statistics: [Average]
+      set_timestamp: false
+
+    - aws_namespace: AWS/ElasticMapReduce
+      aws_metric_name: CoreNodesRunning
+      aws_dimensions: [JobFlowId]
+      aws_statistics: [Average]
+      set_timestamp: false
+
+    - aws_namespace: AWS/ElasticMapReduce
+      aws_metric_name: CoreNodesPending
+      aws_dimensions: [JobFlowId]
+      aws_statistics: [Average]
+      set_timestamp: false
+
+    - aws_namespace: AWS/ElasticMapReduce
+      aws_metric_name: LiveDataNodes
+      aws_dimensions: [JobFlowId]
+      aws_statistics: [Average]
+      set_timestamp: false
+
+    - aws_namespace: AWS/ElasticMapReduce
+      aws_metric_name: MRTotalNodes
+      aws_dimensions: [JobFlowId]
+      aws_statistics: [Average]
+      set_timestamp: false
+
+    - aws_namespace: AWS/ElasticMapReduce
+      aws_metric_name: MRActiveNodes
+      aws_dimensions: [JobFlowId]
+      aws_statistics: [Average]
+      set_timestamp: false
+
+    - aws_namespace: AWS/ElasticMapReduce
+      aws_metric_name: MRLostNodes
+      aws_dimensions: [JobFlowId]
+      aws_statistics: [Average]
+      set_timestamp: false
+
+    - aws_namespace: AWS/ElasticMapReduce
+      aws_metric_name: MRUnhealthyNodes
+      aws_dimensions: [JobFlowId]
+      aws_statistics: [Average]
+      set_timestamp: false
+
+    - aws_namespace: AWS/ElasticMapReduce
+      aws_metric_name: MRDecommissionedNodes
+      aws_dimensions: [JobFlowId]
+      aws_statistics: [Average]
+      set_timestamp: false
+
+    - aws_namespace: AWS/ElasticMapReduce
+      aws_metric_name: MRRebootedNodes
+      aws_dimensions: [JobFlowId]
+      aws_statistics: [Average]
+      set_timestamp: false
+
+    - aws_namespace: AWS/ElasticMapReduce
+      aws_metric_name: S3BytesWritten
+      aws_dimensions: [JobFlowId]
+      aws_statistics: [Average]
+      set_timestamp: false
+
+    - aws_namespace: AWS/ElasticMapReduce
+      aws_metric_name: S3BytesRead
+      aws_dimensions: [JobFlowId]
+      aws_statistics: [Average]
+      set_timestamp: false
+
+    - aws_namespace: AWS/ElasticMapReduce
+      aws_metric_name: HDFSUtilization
+      aws_dimensions: [JobFlowId]
+      aws_statistics: [Average]
+      set_timestamp: false
+
+    - aws_namespace: AWS/ElasticMapReduce
+      aws_metric_name: HDFSBytesRead
+      aws_dimensions: [JobFlowId]
+      aws_statistics: [Average]
+      set_timestamp: false
+
+    - aws_namespace: AWS/ElasticMapReduce
+      aws_metric_name: HDFSBytesWritten
+      aws_dimensions: [JobFlowId]
+      aws_statistics: [Average]
+      set_timestamp: false
+
+    - aws_namespace: AWS/ElasticMapReduce
+      aws_metric_name: MissingBlocks
+      aws_dimensions: [JobFlowId]
+      aws_statistics: [Average]
+      set_timestamp: false
+
+    - aws_namespace: AWS/ElasticMapReduce
+      aws_metric_name: CorruptBlocks
+      aws_dimensions: [JobFlowId]
+      aws_statistics: [Average]
+      set_timestamp: false
+
+    - aws_namespace: AWS/ElasticMapReduce
+      aws_metric_name: TotalLoad
+      aws_dimensions: [JobFlowId]
+      aws_statistics: [Average]
+      set_timestamp: false
+
+    - aws_namespace: AWS/ElasticMapReduce
+      aws_metric_name: MemoryTotalMB
+      aws_dimensions: [JobFlowId]
+      aws_statistics: [Average]
+      set_timestamp: false
+
+    - aws_namespace: AWS/ElasticMapReduce
+      aws_metric_name: MemoryReservedMB
+      aws_dimensions: [JobFlowId]
+      aws_statistics: [Average]
+      set_timestamp: false
+
+    - aws_namespace: AWS/ElasticMapReduce
+      aws_metric_name: MemoryAvailableMB
+      aws_dimensions: [JobFlowId]
+      aws_statistics: [Average]
+      set_timestamp: false
+
+    - aws_namespace: AWS/ElasticMapReduce
+      aws_metric_name: YARNMemoryAvailablePercentage
+      aws_dimensions: [JobFlowId]
+      aws_statistics: [Average]
+      set_timestamp: false
+
+    - aws_namespace: AWS/ElasticMapReduce
+      aws_metric_name: MemoryAllocatedMB
+      aws_dimensions: [JobFlowId]
+      aws_statistics: [Average]
+      set_timestamp: false
+
+    - aws_namespace: AWS/ElasticMapReduce
+      aws_metric_name: PendingDeletionBlocks
+      aws_dimensions: [JobFlowId]
+      aws_statistics: [Average]
+      set_timestamp: false
+
+    - aws_namespace: AWS/ElasticMapReduce
+      aws_metric_name: UnderReplicatedBlocks
+      aws_dimensions: [JobFlowId]
+      aws_statistics: [Average]
+      set_timestamp: false
+
+    - aws_namespace: AWS/ElasticMapReduce
+      aws_metric_name: DfsPendingReplicationBlocks
+      aws_dimensions: [JobFlowId]
+      aws_statistics: [Average]
+      set_timestamp: false
+
+    - aws_namespace: AWS/ElasticMapReduce
+      aws_metric_name: CapacityRemainingGB
+      aws_dimensions: [JobFlowId]
+      aws_statistics: [Average]
+      set_timestamp: false
+
+    - aws_namespace: AWS/ElasticMapReduce
+      aws_metric_name: HbaseBackupFailed
+      aws_dimensions: [JobFlowId]
+      aws_statistics: [Average]
+      set_timestamp: false
+
+    - aws_namespace: AWS/ElasticMapReduce
+      aws_metric_name: MostRecentBackupDuration
+      aws_dimensions: [JobFlowId]
+      aws_statistics: [Average]
+      set_timestamp: false
+
+    - aws_namespace: AWS/ElasticMapReduce
+      aws_metric_name: TimeSinceLastSuccessfulBackup
+      aws_dimensions: [JobFlowId]
+      aws_statistics: [Average]
+      set_timestamp: false


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

This PR adds new chart prometheus-cloudwatch-exporter. This chart is refactored from forked https://github.com/helm/charts/tree/master/stable/prometheus-cloudwatch-exporter.
add posibility to add new region and predefined configs per region in one chart and release, cahrt will deploy one deployment per region.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
