### PR TITLE
Expose HTTP port for Elasticsearch data nodes

### DIFF
--- a/stable/elasticsearch/Chart.yaml
+++ b/stable/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 name: elasticsearch
 home: https://github.com/AnchorFree/helm-charts
-version: 1.3.0
+version: 1.4.0
 appVersion: 6.6.0
 description: Flexible and powerful open source, distributed real-time search and analytics
   engine.

--- a/stable/elasticsearch/README.md
+++ b/stable/elasticsearch/README.md
@@ -123,6 +123,7 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `data.initResources`                 | Data initContainer resources requests & limits                      | `{}`                                                |
 | `data.additionalJavaOpts`            | Parameters to be added to `ES_JAVA_OPTS` environment variable for data | `""`                                             |
 | `data.exposeHttp`                    | Expose http port 9200 on data Pods for monitoring, etc              | `false`                                             |
+| `data.serviceType`                   | Data node service type                                              | `ClusterIP`                                         |
 | `data.replicas`                      | Data node replicas (statefulset)                                    | `2`                                                 |
 | `data.masterEligible`                | Data node master eligibility                                        | `false`                                             |
 | `data.resources`                     | Data node resources requests & limits                               | `{} - cpu limit must be an integer`                 |

--- a/stable/elasticsearch/templates/data-svc.yaml
+++ b/stable/elasticsearch/templates/data-svc.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.data.exposeHttp }}
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: {{ template "elasticsearch.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: "{{ .Values.data.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "elasticsearch.data.fullname" . }}
+spec:
+  ports:
+    - name: http
+      port: 9200
+      targetPort: http
+  selector:
+    app: {{ template "elasticsearch.name" . }}
+    component: "{{ .Values.data.name }}"
+    release: {{ .Release.Name }}
+  type: {{ .Values.data.serviceType }}
+{{- end }}

--- a/stable/elasticsearch/values.yaml
+++ b/stable/elasticsearch/values.yaml
@@ -169,6 +169,7 @@ master:
 data:
   name: data
   exposeHttp: false
+  serviceType: ClusterIP
   replicas: 2
   masterEligible: false
   heapSize: "1536m"


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Adds service to expose port 9200 at data nodes. This allows prometheus to collect metrics from these nodes.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
