### PR TITLE
Add option to turn off creation of default services

### DIFF
--- a/stable/elasticsearch/Chart.yaml
+++ b/stable/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 name: elasticsearch
 home: https://github.com/AnchorFree/helm-charts
-version: 1.4.0
+version: 1.5.0
 appVersion: 6.6.0
 description: Flexible and powerful open source, distributed real-time search and analytics
   engine.

--- a/stable/elasticsearch/README.md
+++ b/stable/elasticsearch/README.md
@@ -85,8 +85,9 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `client.nodeSelector`                | Node labels for client pod assignment                               | `{}`                                                |
 | `client.tolerations`                 | Client tolerations                                                  | `[]`                                                |
 | `client.serviceAnnotations`          | Client Service annotations                                          | `{}`                                                |
-| `client.serviceType`                 | Client service type                                                 | `ClusterIP`                                         |
-| `client.serviceName`                 | Client service name                                                 | `""`                                                |
+| `client.service.create`              | Client service on\off                                               | `true`                                              |
+| `client.service.type`                | Client service type                                                 | `ClusterIP`                                         |
+| `client.service.name`                | Client service name                                                 | `""`                                                |
 | `client.loadBalancerIP`              | Client loadBalancerIP                                               | `{}`                                                |
 | `client.loadBalancerSourceRanges`    | Client loadBalancerSourceRanges                                     | `{}`                                                |
 | `client.antiAffinity`                | Client anti-affinity policy                                         | `soft`                                              |
@@ -101,7 +102,8 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `client.ingress.tls`                 | Client Ingress TLS configuration                                    | `[]`                                                |
 | `master.initResources`               | Master initContainer resources requests & limits                    | `{}`                                                |
 | `master.additionalJavaOpts`          | Parameters to be added to `ES_JAVA_OPTS` environment variable for master | `""`                                           |
-| `master.exposeHttp`                  | Expose http port 9200 on master Pods for monitoring, etc            | `false`                                             |
+| `master.service.create`              | Master service on\off                                               | `true`                                             |
+| `master.service.exposeHttp`          | Expose http port 9200 on master Pods for monitoring, etc            | `false`                                             |
 | `master.name`                        | Master component name                                               | `master`                                            |
 | `master.replicas`                    | Master node replicas (deployment)                                   | `2`                                                 |
 | `master.resources`                   | Master node resources requests & limits                             | `{} - cpu limit must be an integer`                 |

--- a/stable/elasticsearch/templates/NOTES.txt
+++ b/stable/elasticsearch/templates/NOTES.txt
@@ -7,12 +7,12 @@ Elasticsearch can be accessed:
     {{ template "elasticsearch.client.fullname" . }}.{{ .Release.Namespace }}.svc
 
   * From outside the cluster, run these commands in the same shell:
-    {{- if contains "NodePort" .Values.client.serviceType }}
+    {{- if contains "NodePort" .Values.client.service.type }}
 
     export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "elasticsearch.client.fullname" . }})
     export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
     echo http://$NODE_IP:$NODE_PORT
-    {{- else if contains "LoadBalancer" .Values.client.serviceType }}
+    {{- else if contains "LoadBalancer" .Values.client.service.type }}
 
      WARNING: You have likely exposed your Elasticsearch cluster direct to the internet.
               Elasticsearch does not implement any security for public facing clusters by default.
@@ -23,7 +23,7 @@ Elasticsearch can be accessed:
 
     export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "elasticsearch.client.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
     echo http://$SERVICE_IP:9200
-    {{- else if contains "ClusterIP"  .Values.client.serviceType }}
+    {{- else if contains "ClusterIP"  .Values.client.service.type }}
 
     export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "elasticsearch.name" . }},component={{ .Values.client.name }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
     echo "Visit http://127.0.0.1:9200 to use Elasticsearch"

--- a/stable/elasticsearch/templates/client-svc.yaml
+++ b/stable/elasticsearch/templates/client-svc.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.client.service.create }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -7,8 +8,8 @@ metadata:
     component: "{{ .Values.client.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-{{- if .Values.client.serviceName }}
-  name: {{ .Values.client.serviceName }}
+{{- if .Values.client.service.name }}
+  name: {{ .Values.client.service.name }}
 {{- else }}
   name: {{ template "elasticsearch.client.fullname" . }}
 {{- end }}
@@ -26,7 +27,7 @@ spec:
     app: {{ template "elasticsearch.name" . }}
     component: "{{ .Values.client.name }}"
     release: {{ .Release.Name }}
-  type: {{ .Values.client.serviceType }}
+  type: {{ .Values.client.service.type }}
 {{- if .Values.client.loadBalancerIP }}
   loadBalancerIP: "{{ .Values.client.loadBalancerIP }}"
 {{- end }}
@@ -36,3 +37,4 @@ spec:
     - {{ $rangeList }}
     {{end}}
   {{end}}
+{{- end }}

--- a/stable/elasticsearch/templates/master-statefulset.yaml
+++ b/stable/elasticsearch/templates/master-statefulset.yaml
@@ -138,7 +138,7 @@ spec:
         ports:
         - containerPort: 9300
           name: transport
-{{ if .Values.master.exposeHttp }}
+{{ if .Values.master.service.exposeHttp }}
         - containerPort: 9200
           name: http
 {{ end }}

--- a/stable/elasticsearch/templates/master-svc.yaml
+++ b/stable/elasticsearch/templates/master-svc.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.master.service.create }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -21,3 +22,4 @@ spec:
     component: "{{ .Values.master.name }}"
   {{- end }}
     release: {{ .Release.Name }}
+{{- end }}

--- a/stable/elasticsearch/values.yaml
+++ b/stable/elasticsearch/values.yaml
@@ -70,8 +70,10 @@ cluster:
 client:
   name: client
   replicas: 2
-  serviceType: ClusterIP
-  serviceName: ""
+  service:
+    create: true
+    type: ClusterIP
+    name: ""
   loadBalancerIP: {}
   loadBalancerSourceRanges: {}
 ## (dict) If specified, apply these annotations to the client service
@@ -122,7 +124,9 @@ client:
 
 master:
   name: master
-  exposeHttp: false
+  service:
+    create: true
+    exposeHttp: false
   replicas: 3
   heapSize: "512m"
   # additionalJavaOpts: "-XX:MaxRAM=512m"


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

When installing this chart on top of existing Elasticsearch chart installation (in upgrade scenario) it is necessary to have a possibility not to create default services (like **elasticsearch** and **elasticsearch-discovery**), but use existing ones. Otherwise, routing between old ES nodes and new ones becomes broken.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
