### PR TITLE
Vmbackup-sidecar for VictoriaMetrics

### DIFF
--- a/stable/victoria-metrics/Chart.yaml
+++ b/stable/victoria-metrics/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "1.26.0-cluster"
 description: A Helm chart for VictoriaMetrics Cluster
 name: victoria-metrics
-version: 0.2.0
+version: 1.0.0
 home: https://victoriametrics.com/

--- a/stable/victoria-metrics/Chart.yaml
+++ b/stable/victoria-metrics/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "1.26.0-cluster"
 description: A Helm chart for VictoriaMetrics Cluster
 name: victoria-metrics
-version: 1.0.0
+version: 0.3.0
 home: https://victoriametrics.com/

--- a/stable/victoria-metrics/templates/vmstorage-service.yaml
+++ b/stable/victoria-metrics/templates/vmstorage-service.yaml
@@ -22,6 +22,12 @@ spec:
       targetPort: vmselect
       protocol: TCP
       name: vmselect
+{{- if .Values.vmstorage.backupSidecar.enabled }}
+    - port: {{ .Values.vmstorage.service.vmbackupPort }}
+      targetPort: vmbackup
+      protocol: TCP
+      name: vmbackup
+{{- end }}
   selector:
     app.kubernetes.io/name: {{ include "victoria-metrics.fullname" . }}-vmstorage
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/stable/victoria-metrics/templates/vmstorage-statefulset.yaml
+++ b/stable/victoria-metrics/templates/vmstorage-statefulset.yaml
@@ -68,6 +68,52 @@ spec:
               {{- else }}
               name: vmstorage-data
               {{- end }}
+        {{- if .Values.vmstorage.backupSidecar.enabled }}
+        {{- with .Values.vmstorage.backupSidecar }}
+        - name: backup-sidecar
+          image: "{{ .image.repository }}:{{ .image.tag }}"
+          imagePullPolicy: {{ .image.pullPolicy }}
+          ports:
+            - name: vmbackup
+              containerPort: {{ .containerPort }}
+              protocol: TCP
+          env:
+            {{- range $key, $value := .env }}
+            - name: {{ $key | quote }}
+              value: {{ tpl $value $ | quote }}
+            {{- end }}
+        {{- if .livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: vmbackup
+            initialDelaySeconds: {{ .livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .livenessProbe.failureThreshold}}
+        {{- end }}
+        {{- if .readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: vmbackup
+            initialDelaySeconds: {{ .readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .readinessProbe.successThreshold }}
+            failureThreshold: {{ .readinessProbe.failureThreshold}}
+        {{- end }}
+          resources:
+            {{- toYaml .resources | nindent 12 }}
+        {{- end }}
+          volumeMounts:
+            - mountPath: /vmstorage-data
+              {{- if .Values.vmstorage.persistence.enabled }}
+              name: {{ .Values.vmstorage.persistence.name }}
+              {{- else }}
+              name: vmstorage-data
+              {{- end }}
+        {{- end }}
       {{- with .Values.vmstorage.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/stable/victoria-metrics/values.yaml
+++ b/stable/victoria-metrics/values.yaml
@@ -122,6 +122,7 @@ vmstorage:
     httpPort: 8482
     vminsertPort: 8400
     vmselectPort: 8401
+    vmbackupPort: &backupPort 8488
 
   serviceMonitor:
     enabled: false
@@ -155,6 +156,23 @@ vmstorage:
   tolerations: []
 
   affinity: {}
+
+  backupSidecar:
+    enabled: true
+
+    image:
+      repository: anchorfree/vmbackup-sidecar
+      tag: 0.3.0
+      pullPolicy: IfNotPresent
+
+    containerPort: *backupPort
+    env: {}
+    resources: {}
+
+    # https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+    livenessProbe: {}
+    readinessProbe: {}
+
 
 ingress:
   enabled: false


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Add possibility to enable [vmbackup-sidecar](https://github.com/AnchorFree/vmbackup-sidecar) service to enable snapshotting and syncing of `vmstorage` data into S3.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
