### PR TITLE
Add possibility to set AWS creds as env vars

### DIFF
--- a/stable/victoria-metrics/Chart.yaml
+++ b/stable/victoria-metrics/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "1.26.0-cluster"
 description: A Helm chart for VictoriaMetrics Cluster
 name: victoria-metrics
-version: 0.3.0
+version: 0.4.0
 home: https://victoriametrics.com/

--- a/stable/victoria-metrics/templates/awscreds-secret.yaml
+++ b/stable/victoria-metrics/templates/awscreds-secret.yaml
@@ -1,0 +1,16 @@
+{{- if and ( .Values.vmstorage.backupSidecar.enabled ) ( .Values.vmstorage.backupSidecar.awsCredentials ) }}
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: aws-s3-credentials
+  labels:
+    app.kubernetes.io/name: aws-s3-credentials
+    app.kubernetes.io/component: vmstorage
+    {{- include "victoria-metrics.common-labels" . | nindent 4 }}
+data:
+{{- with .Values.vmstorage.backupSidecar.awsCredentials }}
+  aws-access-key-id: {{ .accessKeyId | b64enc }}
+  aws-secret-access-key: {{ .secretAccessKey | b64enc }}
+{{- end }}
+{{- end }}

--- a/stable/victoria-metrics/templates/vmstorage-statefulset.yaml
+++ b/stable/victoria-metrics/templates/vmstorage-statefulset.yaml
@@ -20,6 +20,8 @@ spec:
         app.kubernetes.io/name: {{ include "victoria-metrics.fullname" . }}-vmstorage
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: vmstorage
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/awscreds-secret.yaml") . | sha256sum }}
     spec:
       terminationGracePeriodSeconds: {{ .Values.vmstorage.terminationGracePeriodSeconds | int }}
     {{- with .Values.vmstorage.imagePullSecrets }}
@@ -81,6 +83,18 @@ spec:
             {{- range $key, $value := .env }}
             - name: {{ $key | quote }}
               value: {{ tpl $value $ | quote }}
+            {{- end }}
+            {{- if .awsCredentials }}
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws-s3-credentials
+                  key: aws-access-key-id
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws-s3-credentials
+                  key: aws-secret-access-key
             {{- end }}
         {{- if .livenessProbe.enabled }}
           livenessProbe:

--- a/stable/victoria-metrics/values.yaml
+++ b/stable/victoria-metrics/values.yaml
@@ -169,6 +169,8 @@ vmstorage:
     env: {}
     resources: {}
 
+    awsCredentials: {}
+
     # https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
     livenessProbe: {}
     readinessProbe: {}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

AWS credentials setup to access S3 bucket.


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
