### PR TITLE
CronJob for vmstorage backups

### DIFF
--- a/stable/victoria-metrics/Chart.yaml
+++ b/stable/victoria-metrics/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "1.27.2-cluster"
 description: A Helm chart for VictoriaMetrics Cluster
 name: victoria-metrics
-version: 0.5.0
+version: 0.6.0
 home: https://victoriametrics.com/

--- a/stable/victoria-metrics/templates/_helpers.tpl
+++ b/stable/victoria-metrics/templates/_helpers.tpl
@@ -74,3 +74,15 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- printf "- --storageNode=%s-%s-%d.%s-%s.%s.svc.%s:8400\n" $pod "vmstorage" $i $svc "vmstorage" $namespace $dnsSuffix -}}
 {{- end -}}
 {{- end -}}
+
+{{/**/}}
+{{- define "victoria-metrics.vmstorage.backup-pod-fqdn" -}}
+{{- $pod := include "victoria-metrics.fullname" . -}}
+{{- $svc := include "victoria-metrics.fullname" . -}}
+{{- $namespace := .Release.Namespace -}}
+{{- $dnsSuffix := .Values.clusterDomainSuffix -}}
+{{- $port := .Values.vmstorage.service.vmbackupPort | int -}}
+{{- range $i := until (.Values.vmstorage.replicaCount | int) -}}
+{{- printf "curl -sS %s-%s-%d.%s-%s.%s.svc.%s:%d/backup/create &\n" $pod "vmstorage" $i $svc "vmstorage" $namespace $dnsSuffix $port -}}
+{{- end -}}
+{{- end -}}

--- a/stable/victoria-metrics/templates/backup-cronjob.yaml
+++ b/stable/victoria-metrics/templates/backup-cronjob.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.vmstorage.backupSidecar.enabled }}
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: "{{ template "victoria-metrics.fullname" . }}-backup"
+  labels:
+    app.kubernetes.io/name: {{ include "victoria-metrics.fullname" . }}-backup-cronjob
+    app.kubernetes.io/component: vmstorage
+    {{ include "victoria-metrics.common-labels" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.vmstorage.backupSidecar.cronjob.schedule | quote }}
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: {{ include "victoria-metrics.fullname" . }}-backup-cronjob
+            app.kubernetes.io/instance: {{ .Release.Name }}
+            app.kubernetes.io/component: vmstorage
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: vmstorage-backup
+            image: {{ .Values.vmstorage.backupSidecar.cronjob.image }}
+            imagePullPolicy: IfNotPresent
+            command:
+            - /bin/sh
+            args:
+            - '-c'
+            - |
+{{- include "victoria-metrics.vmstorage.backup-pod-fqdn" . | nindent 14 }}
+              wait
+{{- end }}

--- a/stable/victoria-metrics/values.yaml
+++ b/stable/victoria-metrics/values.yaml
@@ -165,6 +165,10 @@ vmstorage:
       tag: 0.3.0
       pullPolicy: IfNotPresent
 
+    cronjob:
+      schedule: "0 1 * * *"
+      image: "byrnedo/alpine-curl:0.1.7"
+
     containerPort: *backupPort
     env: {}
     resources: {}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Implements cronjob to execute `vmstorage` backups via [vmbackup-sidecar](https://github.com/AnchorFree/vmbackup-sidecar).

#### Special notes for your reviewer:

Rendered CronJob sample:

```yaml
apiVersion: batch/v1beta1
kind: CronJob
metadata:
  creationTimestamp: "2019-09-09T15:25:32Z"
  labels:
    app.kubernetes.io/component: vmstorage
    app.kubernetes.io/instance: victoria-metrics
    app.kubernetes.io/managed-by: Tiller
    app.kubernetes.io/name: victoria-metrics-backup-cronjob
    app.kubernetes.io/version: 1.27.2-cluster
    helm.sh/chart: victoria-metrics-0.5.0
  name: victoria-metrics-backup
  namespace: default
  resourceVersion: "16331"
  selfLink: /apis/batch/v1beta1/namespaces/default/cronjobs/victoria-metrics-backup
  uid: 0ffa4e08-d316-11e9-998b-1e03bb03ebff
spec:
  concurrencyPolicy: Forbid
  failedJobsHistoryLimit: 1
  jobTemplate:
    metadata:
      creationTimestamp: null
    spec:
      template:
        metadata:
          creationTimestamp: null
          labels:
            app.kubernetes.io/component: vmstorage
            app.kubernetes.io/instance: victoria-metrics
            app.kubernetes.io/name: victoria-metrics-backup-cronjob
        spec:
          containers:
          - args:
            - -c
            - |
              curl -sS victoria-metrics-vmstorage-0.victoria-metrics-vmstorage.default.svc.cluster.local:8488/backup/create &
              curl -sS victoria-metrics-vmstorage-1.victoria-metrics-vmstorage.default.svc.cluster.local:8488/backup/create &
              curl -sS victoria-metrics-vmstorage-2.victoria-metrics-vmstorage.default.svc.cluster.local:8488/backup/create &

              wait
            command:
            - /bin/sh
            image: byrnedo/alpine-curl:0.1.7
            imagePullPolicy: IfNotPresent
            name: vmstorage-backup
            resources: {}
            terminationMessagePath: /dev/termination-log
            terminationMessagePolicy: File
          dnsPolicy: ClusterFirst
          restartPolicy: OnFailure
          schedulerName: default-scheduler
          securityContext: {}
          terminationGracePeriodSeconds: 30
  schedule: 0 15 * * *
  successfulJobsHistoryLimit: 3
  suspend: false
status: {}
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
