### PR TITLE
CronJob per vmstorage instance

### DIFF
--- a/stable/victoria-metrics/Chart.yaml
+++ b/stable/victoria-metrics/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "1.27.3-cluster"
 description: A Helm chart for VictoriaMetrics Cluster
 name: victoria-metrics
-version: 0.9.0
+version: 0.10.0
 home: https://victoriametrics.com/

--- a/stable/victoria-metrics/templates/_helpers.tpl
+++ b/stable/victoria-metrics/templates/_helpers.tpl
@@ -74,15 +74,3 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- printf "- --storageNode=%s-%s-%d.%s-%s.%s.svc.%s:8400\n" $pod "vmstorage" $i $svc "vmstorage" $namespace $dnsSuffix -}}
 {{- end -}}
 {{- end -}}
-
-{{/**/}}
-{{- define "victoria-metrics.vmstorage.backup-pod-fqdn" -}}
-{{- $pod := include "victoria-metrics.fullname" . -}}
-{{- $svc := include "victoria-metrics.fullname" . -}}
-{{- $namespace := .Release.Namespace -}}
-{{- $dnsSuffix := .Values.clusterDomainSuffix -}}
-{{- $port := .Values.vmstorage.service.vmbackupPort | int -}}
-{{- range $i := until (.Values.vmstorage.replicaCount | int) -}}
-{{- printf "curl -sS %s-%s-%d.%s-%s.%s.svc.%s:%d/backup/create &\n" $pod "vmstorage" $i $svc "vmstorage" $namespace $dnsSuffix $port -}}
-{{- end -}}
-{{- end -}}

--- a/stable/victoria-metrics/templates/backup-cronjob.yaml
+++ b/stable/victoria-metrics/templates/backup-cronjob.yaml
@@ -36,6 +36,7 @@ spec:
             imagePullPolicy: IfNotPresent
             command:
             - /bin/sh
+            # TODO: move printf into _helpers.tpl
             args:
             - '-c'
             - |

--- a/stable/victoria-metrics/templates/backup-cronjob.yaml
+++ b/stable/victoria-metrics/templates/backup-cronjob.yaml
@@ -1,34 +1,44 @@
 {{- if .Values.vmstorage.backupSidecar.enabled }}
+{{- $pod := include "victoria-metrics.fullname" . -}}
+{{- $svc := include "victoria-metrics.fullname" . -}}
+{{- $namespace := .Release.Namespace -}}
+{{- $dnsSuffix := .Values.clusterDomainSuffix -}}
+{{- $port := .Values.vmstorage.service.vmbackupPort | int -}}
+
+# range creates boxed context which should be accessed via $
+# https://github.com/helm/helm/issues/1311
+{{- range $i := until ( .Values.vmstorage.replicaCount | int ) }}
+---
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: "{{ template "victoria-metrics.fullname" . }}-backup"
+  name: "{{ template "victoria-metrics.fullname" $ }}-backup-pod-{{ $i }}"
   labels:
-    app.kubernetes.io/name: {{ include "victoria-metrics.fullname" . }}-backup-cronjob
+    app.kubernetes.io/name: {{ include "victoria-metrics.fullname" $ }}-backup-cronjob
     app.kubernetes.io/component: vmstorage
-    {{ include "victoria-metrics.common-labels" . | nindent 4 }}
+    {{ include "victoria-metrics.common-labels" $ | nindent 4 }}
 spec:
-  schedule: {{ .Values.vmstorage.backupSidecar.cronjob.schedule | quote }}
+  schedule: {{ $.Values.vmstorage.backupSidecar.cronjob.schedule | quote }}
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
       template:
         metadata:
           labels:
-            app.kubernetes.io/name: {{ include "victoria-metrics.fullname" . }}-backup-cronjob
-            app.kubernetes.io/instance: {{ .Release.Name }}
+            app.kubernetes.io/name: {{ include "victoria-metrics.fullname" $ }}-backup-cronjob
+            app.kubernetes.io/instance: {{ $.Release.Name }}
             app.kubernetes.io/component: vmstorage
         spec:
           restartPolicy: OnFailure
           containers:
           - name: vmstorage-backup
-            image: {{ .Values.vmstorage.backupSidecar.cronjob.image }}
+            image: {{ $.Values.vmstorage.backupSidecar.cronjob.image }}
             imagePullPolicy: IfNotPresent
             command:
             - /bin/sh
             args:
             - '-c'
             - |
-{{- include "victoria-metrics.vmstorage.backup-pod-fqdn" . | nindent 14 }}
-              wait
+{{- printf "curl -sS %s-%s-%d.%s-%s.%s.svc.%s:%d/backup/create" $pod "vmstorage" $i $svc "vmstorage" $namespace $dnsSuffix $port | nindent 14 }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Creates dedicated CronJob for every **vmstorage** instance. This allows to properly catch exit statuses of every job and schedule them independently.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped