### PR TITLE
Update VictoriaMetrics components to v1.28.1-cluster

### DIFF
--- a/stable/victoria-metrics/Chart.yaml
+++ b/stable/victoria-metrics/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-appVersion: "1.27.3-cluster"
+appVersion: "1.28.1-cluster"
 description: A Helm chart for VictoriaMetrics Cluster
 name: victoria-metrics
-version: 0.10.0
+version: 0.11.0
 home: https://victoriametrics.com/

--- a/stable/victoria-metrics/values.yaml
+++ b/stable/victoria-metrics/values.yaml
@@ -15,7 +15,7 @@ vminsert:
 
   image:
     repository: victoriametrics/vminsert
-    tag: v1.27.3-cluster
+    tag: &version v1.28.1-cluster
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []
@@ -59,7 +59,7 @@ vmselect:
 
   image:
     repository: victoriametrics/vmselect
-    tag: v1.27.3-cluster
+    tag: *version
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []
@@ -112,7 +112,7 @@ vmstorage:
 
   image:
     repository: victoriametrics/vmstorage
-    tag: v1.27.3-cluster
+    tag: *version
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []

--- a/stable/victoria-metrics/values.yaml
+++ b/stable/victoria-metrics/values.yaml
@@ -167,7 +167,7 @@ vmstorage:
 
     image:
       repository: anchorfree/vmbackup-sidecar
-      tag: 0.3.0
+      tag: 0.10.0-alpha.1
       pullPolicy: IfNotPresent
 
     cronjob:


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

- update `vminsert`, `vmselect`, `vmstorage` to **v1.28.1-cluster**
- update `vmbackup-sidecar` to **v0.10.0-alpha.1**

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
