### PR TITLE
Make k8s-rumors compatible with k8s v1.16.x

### DIFF
--- a/stable/k8s-rumors/Chart.yaml
+++ b/stable/k8s-rumors/Chart.yaml
@@ -2,5 +2,5 @@ appVersion: 1.0.0
 apiVersion: v1
 name: k8s-rumors
 description: A secret replicator for k8s.
-version: 1.0.0
+version: 1.1.0
 home: https://github.com/AnchorFree/k8s-rumors

--- a/stable/k8s-rumors/templates/deployment.yaml
+++ b/stable/k8s-rumors/templates/deployment.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

To fix this:

```
FAILED RELEASES:
NAME
k8s-rumors
in ./helmfile_k8s_rumors.yaml: failed processing release k8s-rumors: helm3 exited with status 1:
  Error: unable to build kubernetes objects from release manifest: unable to recognize "": no matches for kind "Deployment" in version "apps/v1beta1"
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
