### PR TITLE
Add capi-aws-cluster chart

### DIFF
--- a/stable/capi-aws-cluster/.helmignore
+++ b/stable/capi-aws-cluster/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/stable/capi-aws-cluster/Chart.yaml
+++ b/stable/capi-aws-cluster/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: capi-aws-cluster
+description: A Helm chart to deploy Kubernetes workload cluster in AWS
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application.
+appVersion: 1.16.2

--- a/stable/capi-aws-cluster/templates/_helpers.tpl
+++ b/stable/capi-aws-cluster/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "capi-aws-cluster.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "capi-aws-cluster.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "capi-aws-cluster.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "capi-aws-cluster.labels" -}}
+helm.sh/chart: {{ include "capi-aws-cluster.chart" . }}
+{{ include "capi-aws-cluster.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "capi-aws-cluster.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "capi-aws-cluster.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "capi-aws-cluster.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "capi-aws-cluster.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/stable/capi-aws-cluster/templates/cluster.yaml
+++ b/stable/capi-aws-cluster/templates/cluster.yaml
@@ -1,0 +1,35 @@
+apiVersion: cluster.x-k8s.io/v1alpha2
+kind: Cluster
+metadata:
+  name: {{ include "capi-aws-cluster.fullname" . }}
+  labels:
+    {{- include "capi-aws-cluster.labels" . | nindent 4 }}
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+        {{- toYaml .Values.cluster.network.cidrBlocks | nindent 8 }}
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+    kind: AWSCluster
+    name: {{ include "capi-aws-cluster.fullname" . }}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+kind: AWSCluster
+metadata:
+  name: {{ include "capi-aws-cluster.fullname" . }}
+  labels:
+    {{- include "capi-aws-cluster.labels" . | nindent 4 }}
+spec:
+  # Change this value to the region you want to deploy the cluster in.
+  region: {{ .Values.cluster.region }}
+  # Change this value to a valid SSH Key Pair present in your AWS Account.
+  sshKeyName: {{ .Values.cluster.sshKeyName }}
+  networkSpec:
+    subnets:
+    - availabilityZone: {{ .Values.cluster.region }}a
+      cidrBlock: 10.0.1.0/24
+      isPublic: true
+    - availabilityZone: {{ .Values.cluster.region }}a
+      cidrBlock: 10.0.2.0/24
+      isPublic: false

--- a/stable/capi-aws-cluster/templates/machine-deployment.yaml
+++ b/stable/capi-aws-cluster/templates/machine-deployment.yaml
@@ -1,0 +1,67 @@
+apiVersion: cluster.x-k8s.io/v1alpha2
+kind: MachineDeployment
+metadata:
+  name: {{ include "capi-aws-cluster.fullname" . }}-worker
+  labels:
+    {{- include "capi-aws-cluster.labels" . | nindent 4 }}
+    cluster.x-k8s.io/cluster-name: {{ include "capi-aws-cluster.fullname" . }}
+    # Labels beyond this point are for example purposes,
+    # feel free to add more or change with something more meaningful.
+    # Sync these values with spec.selector.matchLabels and spec.template.metadata.labels.
+    nodepool: nodepool-0
+spec:
+  replicas: {{ .Values.worker.count }}
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: {{ include "capi-aws-cluster.fullname" . }}
+      nodepool: nodepool-0
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/cluster-name: {{ include "capi-aws-cluster.fullname" . }}
+        nodepool: nodepool-0
+    spec:
+      version: {{ .Values.worker.version }}
+      bootstrap:
+        configRef:
+          name: {{ include "capi-aws-cluster.fullname" . }}-worker
+          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+          kind: KubeadmConfigTemplate
+      infrastructureRef:
+        name: {{ include "capi-aws-cluster.fullname" . }}-worker
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+        kind: AWSMachineTemplate
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+kind: AWSMachineTemplate
+metadata:
+  name: {{ include "capi-aws-cluster.fullname" . }}-worker
+  labels:
+    {{- include "capi-aws-cluster.labels" . | nindent 4 }}
+spec:
+  template:
+    spec:
+      instanceType: {{ .Values.worker.size }}
+      rootDeviceSize: {{ .Values.worker.rootDeviceSize }}
+      availabilityZone: {{ .Values.cluster.region }}a
+      # This IAM profile is part of the pre-requisites.
+      iamInstanceProfile: "nodes.cluster-api-provider-aws.sigs.k8s.io"
+      # Change this value to a valid SSH Key Pair present in your AWS Account.
+      sshKeyName: {{ .Values.worker.sshKeyName }}
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+kind: KubeadmConfigTemplate
+metadata:
+  name: {{ include "capi-aws-cluster.fullname" . }}-worker
+  labels:
+    {{- include "capi-aws-cluster.labels" . | nindent 4 }}
+spec:
+  template:
+    spec:
+      # For more information about these values,
+      # refer to the Kubeadm Bootstrap Provider documentation.
+      joinConfiguration:
+        nodeRegistration:
+          name: {{`'{{ ds.meta_data.hostname }}'`}}
+          kubeletExtraArgs:
+            cloud-provider: aws

--- a/stable/capi-aws-cluster/templates/master-node.yaml
+++ b/stable/capi-aws-cluster/templates/master-node.yaml
@@ -1,0 +1,56 @@
+apiVersion: cluster.x-k8s.io/v1alpha2
+kind: Machine
+metadata:
+  name: {{ include "capi-aws-cluster.fullname" . }}-master
+  labels:
+    {{- include "capi-aws-cluster.labels" . | nindent 4 }}
+    cluster.x-k8s.io/control-plane: "true"
+    cluster.x-k8s.io/cluster-name: {{ include "capi-aws-cluster.fullname" . }}
+spec:
+  version: {{ .Values.master.version }}
+  bootstrap:
+    configRef:
+      apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+      kind: KubeadmConfig
+      name: {{ include "capi-aws-cluster.fullname" . }}-master
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+    kind: AWSMachine
+    name: {{ include "capi-aws-cluster.fullname" . }}-master
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+kind: AWSMachine
+metadata:
+  name: {{ include "capi-aws-cluster.fullname" . }}-master
+  labels:
+    {{- include "capi-aws-cluster.labels" . | nindent 4 }}
+spec:
+  instanceType: {{ .Values.master.size }}
+  rootDeviceSize: {{ .Values.master.rootDeviceSize }}
+  availabilityZone: {{ .Values.cluster.region }}a
+  # This IAM profile is part of the pre-requisites.
+  iamInstanceProfile: "control-plane.cluster-api-provider-aws.sigs.k8s.io"
+  # Change this value to a valid SSH Key Pair present in your AWS Account.
+  sshKeyName: {{ .Values.master.sshKeyName }}
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+kind: KubeadmConfig
+metadata:
+  name: {{ include "capi-aws-cluster.fullname" . }}-master
+  labels:
+    {{- include "capi-aws-cluster.labels" . | nindent 4 }}
+spec:
+  # For more information about these values,
+  # refer to the Kubeadm Bootstrap Provider documentation.
+  initConfiguration:
+    nodeRegistration:
+      name: {{`'{{ ds.meta_data.hostname }}'`}}
+      kubeletExtraArgs:
+        cloud-provider: aws
+  clusterConfiguration:
+    apiServer:
+      extraArgs:
+        cloud-provider: aws
+    controllerManager:
+      extraArgs:
+        cloud-provider: aws

--- a/stable/capi-aws-cluster/values.yaml
+++ b/stable/capi-aws-cluster/values.yaml
@@ -1,0 +1,21 @@
+cluster:
+  network:
+    cidrBlocks:
+      - "192.168.0.0/16"
+  sshKeyName: &ssh my-key
+  region: eu-central-1
+
+master:
+  version: &ver v1.16.2
+  size: t2.medium
+  # Specifies size (in Gi) of the root storage device
+  rootDeviceSize: 8
+  sshKeyName: *ssh
+
+worker:
+  count: 1
+  version: *ver
+  size: t2.micro
+  # Specifies size (in Gi) of the root storage device
+  rootDeviceSize: 8
+  sshKeyName: *ssh


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

A chart to create workload clusters in AWS via [capi](https://github.com/kubernetes-sigs/cluster-api) and [capa](https://github.com/kubernetes-sigs/cluster-api-provider-aws).


#### Special notes for your reviewer:

This is a very basic chart, with no HA support yet. We can build on top of it.
