### PR TITLE
DEVOPS-4431 Adjust VM chart for prod needs

### DIFF
--- a/stable/victoria-metrics/Chart.yaml
+++ b/stable/victoria-metrics/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "v1.35.4-cluster"
 description: A Helm chart for VictoriaMetrics Cluster
 name: victoria-metrics
-version: 0.17.0
+version: 0.18.0
 home: https://victoriametrics.com/

--- a/stable/victoria-metrics/templates/backup-cronjob.yaml
+++ b/stable/victoria-metrics/templates/backup-cronjob.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.vmstorage.backupSidecar.enabled }}
+{{- if and ( .Values.vmstorage.enabled ) ( .Values.vmstorage.backupSidecar.enabled ) }}
 {{- $pod := include "victoria-metrics.fullname" . -}}
 {{- $svc := include "victoria-metrics.fullname" . -}}
 {{- $namespace := .Release.Namespace -}}

--- a/stable/victoria-metrics/templates/ingress.yaml
+++ b/stable/victoria-metrics/templates/ingress.yaml
@@ -27,11 +27,11 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          - path: /select
-            backend:
-              serviceName: {{ $fullName }}-vmselect
-              servicePort: http
           - path: /insert
+            backend:
+              serviceName: {{ $fullName }}-vminsert
+              servicePort: http
+          - path: /health
             backend:
               serviceName: {{ $fullName }}-vminsert
               servicePort: http

--- a/stable/victoria-metrics/templates/vminsert-deployment.yaml
+++ b/stable/victoria-metrics/templates/vminsert-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.vminsert.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -33,7 +34,9 @@ spec:
           image: "{{ .Values.vminsert.image.repository }}:{{ if not .Values.vminsert.image.tag }}{{ .Chart.AppVersion }}{{ else }}{{ .Values.vminsert.image.tag }}{{ end }}"
           imagePullPolicy: {{ .Values.vminsert.image.pullPolicy }}
           args:
+        {{ if .Values.vmstorage.enabled }}
           {{- include "victoria-metrics.vminsert.vmstorage-pod-fqdn" . | nindent 12 }}
+        {{- end }}
           {{- range $key, $value := .Values.vminsert.extraArgs }}
             - --{{ $key }}={{ $value }}
           {{- end }}
@@ -68,3 +71,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+{{- end }}

--- a/stable/victoria-metrics/templates/vminsert-service.yaml
+++ b/stable/victoria-metrics/templates/vminsert-service.yaml
@@ -1,3 +1,4 @@
+{{- if and ( .Values.vminsert.enabled ) ( .Values.vminsert.service.enabled ) -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -18,3 +19,4 @@ spec:
     app.kubernetes.io/name: {{ include "victoria-metrics.fullname" . }}-vminsert
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: vminsert
+{{- end }}

--- a/stable/victoria-metrics/templates/vminsert-servicemonitor.yaml
+++ b/stable/victoria-metrics/templates/vminsert-servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.vminsert.serviceMonitor.enabled -}}
+{{- if and ( .Values.vminsert.enabled ) ( .Values.vminsert.serviceMonitor.enabled ) -}}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/stable/victoria-metrics/templates/vmselect-service.yaml
+++ b/stable/victoria-metrics/templates/vmselect-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.vmselect.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -18,3 +19,4 @@ spec:
     app.kubernetes.io/name: {{ include "victoria-metrics.fullname" . }}-vmselect
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: vmselect
+{{- end }}

--- a/stable/victoria-metrics/templates/vmselect-servicemonitor.yaml
+++ b/stable/victoria-metrics/templates/vmselect-servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.vmselect.serviceMonitor.enabled -}}
+{{- if and ( .Values.vmselect.enabled ) ( .Values.vmselect.serviceMonitor.enabled ) -}}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/stable/victoria-metrics/templates/vmselect-statefulset.yaml
+++ b/stable/victoria-metrics/templates/vmselect-statefulset.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.vmselect.enabled -}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -94,3 +95,4 @@ spec:
           requests:
             storage: {{ .Values.vmselect.persistence.size | quote }}
   {{- end }}
+{{- end }}

--- a/stable/victoria-metrics/templates/vmstorage-service.yaml
+++ b/stable/victoria-metrics/templates/vmstorage-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.vmstorage.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -32,3 +33,4 @@ spec:
     app.kubernetes.io/name: {{ include "victoria-metrics.fullname" . }}-vmstorage
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: vmstorage
+{{- end }}

--- a/stable/victoria-metrics/templates/vmstorage-servicemonitor.yaml
+++ b/stable/victoria-metrics/templates/vmstorage-servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.vmstorage.serviceMonitor.enabled -}}
+{{- if and ( .Values.vmstorage.enabled ) ( .Values.vmstorage.serviceMonitor.enabled ) -}}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/stable/victoria-metrics/templates/vmstorage-statefulset.yaml
+++ b/stable/victoria-metrics/templates/vmstorage-statefulset.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.vmstorage.enabled -}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -165,3 +166,4 @@ spec:
           requests:
             storage: {{ .Values.vmstorage.persistence.size | quote }}
   {{- end }}
+{{- end }}

--- a/stable/victoria-metrics/templates/vmstorage-statefulset.yaml
+++ b/stable/victoria-metrics/templates/vmstorage-statefulset.yaml
@@ -49,19 +49,26 @@ spec:
             - name: vmselect
               containerPort: 8401
               protocol: TCP
+        {{- if .Values.vmstorage.livenessProbe.enabled }}
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: {{ .Values.vmstorage.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.vmstorage.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.vmstorage.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.vmstorage.livenessProbe.failureThreshold }}
+        {{- end }}
+        {{- if .Values.vmstorage.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
               path: /health
               port: http
-            initialDelaySeconds: 5
-            periodSeconds: 15
-            timeoutSeconds: 5
-          livenessProbe:
-            tcpSocket:
-              port: http
-            initialDelaySeconds: 5
-            periodSeconds: 15
-            timeoutSeconds: 5
+            initialDelaySeconds: {{ .Values.vmstorage.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.vmstorage.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.vmstorage.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.vmstorage.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.vmstorage.readinessProbe.failureThreshold }}
+        {{- end }}
           resources:
             {{- toYaml .Values.vmstorage.resources | nindent 12 }}
           volumeMounts:
@@ -109,7 +116,7 @@ spec:
             initialDelaySeconds: {{ .livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .livenessProbe.timeoutSeconds }}
-            failureThreshold: {{ .livenessProbe.failureThreshold}}
+            failureThreshold: {{ .livenessProbe.failureThreshold }}
         {{- end }}
         {{- if .readinessProbe.enabled }}
           readinessProbe:
@@ -120,7 +127,7 @@ spec:
             periodSeconds: {{ .readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .readinessProbe.timeoutSeconds }}
             successThreshold: {{ .readinessProbe.successThreshold }}
-            failureThreshold: {{ .readinessProbe.failureThreshold}}
+            failureThreshold: {{ .readinessProbe.failureThreshold }}
         {{- end }}
           resources:
             {{- toYaml .resources | nindent 12 }}

--- a/stable/victoria-metrics/values.yaml
+++ b/stable/victoria-metrics/values.yaml
@@ -163,6 +163,22 @@ vmstorage:
 
   affinity: {}
 
+  # https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 30
+    periodSeconds: 15
+    timeoutSeconds: 5
+    failureThreshold: 5
+
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 30
+    periodSeconds: 15
+    timeoutSeconds: 5
+    successThreshold: 1
+    failureThreshold: 3
+
   backupSidecar:
     enabled: true
 

--- a/stable/victoria-metrics/values.yaml
+++ b/stable/victoria-metrics/values.yaml
@@ -7,6 +7,7 @@ fullnameOverride: ""
 clusterDomainSuffix: "cluster.local"
 
 vminsert:
+  enabled: true
   replicaCount: 1
 
   terminationGracePeriodSeconds: 60
@@ -20,6 +21,7 @@ vminsert:
   imagePullSecrets: []
 
   service:
+    enabled: true
     type: ClusterIP
     port: 80
 
@@ -50,6 +52,7 @@ vminsert:
   affinity: {}
 
 vmselect:
+  enabled: true
   replicaCount: 1
 
   terminationGracePeriodSeconds: 60
@@ -100,6 +103,7 @@ vmselect:
   affinity: {}
 
 vmstorage:
+  enabled: true
   replicaCount: 1
 
   retentionPeriod: 1


### PR DESCRIPTION
- Allow turn on/off the VM components (make possible to deploy dedicated component as separate helm release)
- Remove `/select` endpoint from ingress (was not actually in prod)
- Add `/health` endpoint for `vminsert` into ingress ([required](https://github.com/VictoriaMetrics/vmctl/issues/16#issuecomment-632675948) to import metrics using `vmctl`)
- Make `vmstorage` probes configurable