### PR TITLE
Mirror cerebro chart from helm/stable

### DIFF
--- a/stable/cerebro/.helmignore
+++ b/stable/cerebro/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+# OWNERS file for Kubernetes
+OWNERS

--- a/stable/cerebro/Chart.yaml
+++ b/stable/cerebro/Chart.yaml
@@ -1,0 +1,10 @@
+name: cerebro
+version: 1.9.5
+appVersion: 0.9.2
+apiVersion: v1
+description: A Helm chart for Cerebro - a web admin tool that replaces Kopf.
+home: https://github.com/lmenezes/cerebro
+icon: https://github.com/lmenezes/cerebro/blob/master/public/img/logo.png
+sources:
+ - https://github.com/lmenezes/cerebro-docker
+ - https://github.com/lmenezes/cerebro

--- a/stable/cerebro/README.md
+++ b/stable/cerebro/README.md
@@ -1,0 +1,98 @@
+# Cerebro
+
+Cerebro is an open source (MIT License) elasticsearch web admin tool built using Scala, Play Framework, AngularJS and Bootstrap.
+
+## Introduction
+
+This chart deploys Cerebro to your cluster via a Deployment and Service.
+Optionally you can also enable ingress.
+Optionally you can use cerebro provided auth by uploading a Secret with the needed env vars (don't forget to set `AUTH_TYPE`).
+
+# Prerequisites
+
+- Kubernetes 1.9+
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`, run:
+
+```bash
+$ helm install --name my-release stable/cerebro
+```
+
+After a few seconds, you should see service statuses being written to the configured output.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```bash
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following table lists the configurable parameters of the cerebro chart and their default values.
+
+|             Parameter               |            Description              |                    Default                |
+|-------------------------------------|-------------------------------------|-------------------------------------------|
+| `replicaCount`                      | Number of replicas                  | `1`                                       |
+| `image.repository`                  | The image to run                    | `lmenezes/cerebro`                        |
+| `image.tag`                         | The image tag to pull               | `0.9.2`                                   |
+| `image.pullPolicy`                  | Image pull policy                   | `IfNotPresent`                            |
+| `image.pullSecrets`                 | Specify image pull secrets          | `nil` (does not add image pull secrets to deployed pods) |
+| `init.image.repository`             | The image to run                    | `docker.io/busybox`                       |
+| `init.image.tag`                    | The image tag to pull               | `musl`                                    |
+| `init.image.pullPolicy`             | Image pull policy                   | `IfNotPresent`                            |
+| `deployment.annotations`            | Annotations for deployment          | `{}`                                      |
+| `deployment.podAnnotations`         | Additional pod annotations          | `{}`                                      |
+| `deployment.labels`                 | Additional labels for deployment    | `{}`                                      |
+| `deployment.podLabels`              | Additional pod labels               | `{}`                                      |
+| `deployment.livenessProbe.enabled`  | Enable livenessProbe                | `true`                                    |
+| `deployment.readinessProbe.enabled` | Enable readinessProbe               | `true`                                    |
+| `service.type`                      | Type of Service                     | `ClusterIP`                               |
+| `service.port`                      | Port for kubernetes service         | `80`                                      |
+| `service.annotations`               | Annotations to add to the service   | `{}`                                      |
+| `service.labels`                    | Labels to add to the service        | `{}`                                      |
+| `resources.requests.cpu`            | CPU resource requests               |                                           |
+| `resources.limits.cpu`              | CPU resource limits                 |                                           |
+| `resources.requests.memory`         | Memory resource requests            |                                           |
+| `resources.limits.memory`           | Memory resource limits              |                                           |
+| `ingress`                           | Settings for ingress                | `{}`                                      |
+| `ingress.labels`                    | Labels to add to the ingress        | `{}`                                      |
+| `priorityClassName`                 | priorityClassName                   | `nil`                                     |
+| `nodeSelector`                      | Settings for nodeselector           | `{}`                                      |
+| `tolerations`                       | Settings for toleration             | `{}`                                      |
+| `affinity`                          | Settings for affinity               | `{}`                                      |
+| `env`                               | Map of env vars (key/value   )      | `{}`                                      |
+| `envFromSecretRef`                  | Reference to Secret with env vars   |                                           |
+| `config.basePath`                   | Application base path               | `/`                                       |
+| `config.restHistorySize`            | Rest request history size per user  | `50`                                      |
+| `config.hosts`                      | A list of known hosts               | `[]`                                      |
+| `config.secret`                     | Secret used to sign session cookies | `(random alphanumeric 64 length string)`  |
+| `config.tlsVerify`                  | Validate Elasticsearch cert         | `true`                                    |
+| `config.tlsCaCert`                  | CA cert to use for cert validation  | `See values.yaml`                         |
+| `securityContext`                   | Security context for pod            | `See values.yaml`                         |
+| `volumes`                           | Volumes defintion                   | `See values.yaml`                         |
+| `volumeMounts`                      | Volume mount defintion              | `See values.yaml`                         |
+
+
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```bash
+$ helm install --name my-release \
+    stable/cerebro
+```
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```bash
+$ helm install --name my-release -f values.yaml stable/cerebro
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)

--- a/stable/cerebro/templates/NOTES.txt
+++ b/stable/cerebro/templates/NOTES.txt
@@ -1,0 +1,19 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "cerebro.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "cerebro.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "cerebro.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "cerebro.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:80
+{{- end }}

--- a/stable/cerebro/templates/_helpers.tpl
+++ b/stable/cerebro/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cerebro.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "cerebro.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cerebro.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/stable/cerebro/templates/configmap.yaml
+++ b/stable/cerebro/templates/configmap.yaml
@@ -1,0 +1,77 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "cerebro.fullname" . }}
+  labels:
+    app: {{ template "cerebro.name" . }}
+    chart: {{ template "cerebro.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  application.conf: |-
+    {{- if .Values.config.secret }}
+    secret = {{ .Values.config.secret | quote }}
+    {{- else }}
+    secret = {{ randAlphaNum 64 | quote }}
+    {{- end }}
+
+    {{- if .Values.config.tlsVerify }}
+    play.ws.ssl.loose.acceptAnyCertificate = false
+    {{- else }}
+    play.ws.ssl.loose.acceptAnyCertificate = true
+    {{- end }}
+    {{- if .Values.config.tlsCaCert }}
+    play.ws.ssl {
+      trustManager = {
+        stores = [
+          { type = "PEM", path = {{ .Values.config.tlsCaCert | quote }} }
+        ]
+      }
+    }
+    {{- end }}
+
+    basePath = {{ .Values.config.basePath | quote }}
+
+    pidfile.path = /dev/null
+
+    rest.history.size = {{ .Values.config.restHistorySize }}
+
+    data.path = "/var/db/cerebro/cerebro.db"
+
+    es = {
+      gzip = true
+    }
+
+    auth = {
+      # either basic or ldap
+      type: ${?AUTH_TYPE}
+      settings {
+        # LDAP
+        url = ${?LDAP_URL}
+        base-dn = ${?LDAP_BASE_DN}
+        method = ${?LDAP_METHOD}
+        user-template = ${?LDAP_USER_TEMPLATE}
+        bind-dn = ${?LDAP_BIND_DN}
+        bind-pw = ${?LDAP_BIND_PWD}
+        group-search {
+          base-dn = ${?LDAP_GROUP_BASE_DN}
+          user-attr = ${?LDAP_USER_ATTR}
+          user-attr-template = ${?LDAP_USER_ATTR_TEMPLATE}
+          group = ${?LDAP_GROUP}
+        }
+
+        # Basic auth
+        username = ${?BASIC_AUTH_USER}
+        password = ${?BASIC_AUTH_PWD}
+      }
+    }
+
+    hosts = [
+      {{- range $index, $element := .Values.config.hosts }}
+      {{ if $index }},{{ end }}
+      {
+        host = {{ $element.host | quote }}
+        name = {{ $element.name | quote }}
+      }
+      {{- end }}
+    ]

--- a/stable/cerebro/templates/deployment.yaml
+++ b/stable/cerebro/templates/deployment.yaml
@@ -1,0 +1,124 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "cerebro.fullname" . }}
+  labels:
+    app: {{ template "cerebro.name" . }}
+    chart: {{ template "cerebro.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- range $key, $value := .Values.deployment.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+{{- if .Values.deployment.annotations }}
+  annotations:
+{{ toYaml .Values.deployment.annotations | indent 4 }}
+{{- end }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      app: {{ template "cerebro.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "cerebro.name" . }}
+        release: {{ .Release.Name }}
+        {{- if .Values.deployment.podLabels }}
+        {{- toYaml .Values.deployment.podLabels | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if .Values.deployment.podAnnotations }}
+        {{- toYaml .Values.deployment.podAnnotations | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- if .Values.securityContext }}
+      securityContext:
+{{ toYaml .Values.securityContext | indent 8 }}
+      {{- end }}
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args: ["-Dconfig.file=/etc/cerebro/application.conf"]
+          ports:
+            - name: http
+              containerPort: 9000
+              protocol: TCP
+          volumeMounts:
+            - name: db
+              mountPath: /var/db/cerebro
+            - name: config
+              mountPath: /etc/cerebro
+            - name: logs
+              mountPath: /opt/cerebro/logs/
+            - name: tmp
+              mountPath: /tmp
+          {{- if .Values.volumeMounts }}
+{{ toYaml .Values.volumeMounts | indent 12 }}
+          {{- end }}
+          {{- if .Values.env }}
+          env:
+          {{- range $index, $element := .Values.env }}
+          - name: {{ $index | quote }}
+            value: {{ $element | quote }}
+          {{- end }}
+          {{- end }}
+          {{- if .Values.envFromSecretRef }}
+          envFrom:
+            - secretRef:
+                name: "{{ .Values.envFromSecretRef }}"
+          {{- end }}
+          {{- if .Values.deployment.livenessProbe.enabled}}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.config.basePath }}
+              port: http
+            initialDelaySeconds: 120
+          {{- end }}
+          {{- if .Values.deployment.readinessProbe.enabled}}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.config.basePath }}
+              port: http
+            initialDelaySeconds: 5
+          {{- end }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+      volumes:
+        - name: db
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: {{ template "cerebro.fullname" . }}
+        - name: logs
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+    {{- if .Values.volumes }}
+{{ toYaml .Values.volumes | indent 8 }}
+    {{- end }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/stable/cerebro/templates/ingress.yaml
+++ b/stable/cerebro/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "cerebro.fullname" . -}}
+{{- $ingressPath := .Values.ingress.path -}}
+apiVersion: {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }} networking.k8s.io/v1beta1 {{- else }} extensions/v1beta1 {{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app: {{ template "cerebro.name" . }}
+    chart: {{ template "cerebro.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.ingress.labels }}
+{{ toYaml .Values.ingress.labels | indent 4 }}
+{{- end }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
+  {{- end }}
+{{- end }}

--- a/stable/cerebro/templates/service.yaml
+++ b/stable/cerebro/templates/service.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "cerebro.fullname" . }}
+  labels:
+    app: {{ template "cerebro.name" . }}
+    chart: {{ template "cerebro.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.service.labels }}
+{{ toYaml .Values.service.labels | indent 4 }}
+{{- end }}
+{{- with .Values.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ template "cerebro.name" . }}
+    release: {{ .Release.Name }}

--- a/stable/cerebro/values.yaml
+++ b/stable/cerebro/values.yaml
@@ -1,0 +1,85 @@
+replicaCount: 1
+revisionHistoryLimit: 3
+env:
+  # AUTH_TYPE: "basic"
+  # BASIC_AUTH_USER: "admin"
+
+image:
+  repository: lmenezes/cerebro
+  # Note: when updating the version, ensure `config` and the ConfigMap are kept
+  # in sync with the default configuration of the upstream image
+  tag: 0.9.2
+  pullPolicy: IfNotPresent
+
+deployment:
+  # additional labels
+  labels: {}
+  annotations: {}
+  podLabels: {}
+  podAnnotations: {}
+  livenessProbe:
+    enabled: true
+  readinessProbe:
+    enabled: true
+
+service:
+  type: ClusterIP
+  port: 80
+  annotations: {}
+  labels: {}
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  labels: {}
+  path: /
+  hosts:
+    - chart-example.local
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+
+priorityClassName: ""
+
+resources: {}
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# Reference to a Secret object with environment variables
+# envFromSecretRef: 'my-secret-ref'
+
+config:
+  basePath: '/'
+  restHistorySize: 50
+  hosts: []
+  #  - host:
+  #    name:
+
+  # Secret used to sign session cookies. If empty it will be replaced with a
+  # random 64 length string
+  secret: ''
+  tlsVerify: true
+  # tlsCaCert: /opt/cerebro/conf/certs/ca.crt
+
+# volumeMounts:
+#   - mountPath: /opt/cerebro/conf/certs/
+#     name: ca_cert_volume
+#     readOnly: true
+# volumes:
+#   - name: ca_cert_volume
+#     secret:
+#       defaultMode: 420
+#       optional: false
+#       secretName: cerebro_ca_cert_secret


### PR DESCRIPTION
Need our own mirror because available distributions contain `apiVersion: v2`, which is not compatible with `helm v2.x.x`.